### PR TITLE
CP-4731: build using the git sm repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,6 @@ install:
 	install -m 755 -d $(SM_STAGING)$(CRON_DEST)
 	install -m 644 $(CRON_JOBS:%=etc/cron.d/%) -t $(SM_STAGING)$(CRON_DEST)
 	ln -sf $(SM_DEST)lcache.py $(SM_STAGING)$(BIN_DEST)tapdisk-cache-stats
-	cp -rf XenCert $(SM_STAGING)$(DEBUG_DEST)
-	cp -rf diskdatatest/diskdatatest $(SM_STAGING)$(DEBUG_DEST)/XenCert/diskdatatest
 
 .PHONY: clean
 clean:

--- a/mk/Makefile
+++ b/mk/Makefile
@@ -10,7 +10,7 @@ include $(B_BASE)/rpmbuild.mk
 .PHONY: $(MY_OBJ_DIR)/version.inc
 $(MY_OBJ_DIR)/version.inc:
 	$(version-makefile) > $@
-	$(call hg_cset_number,$(REPONAME)) >> $@
+	$(call git_cset_number,$(REPONAME)) >> $@
 	echo SM_VERSION := \$$\(PLATFORM_VERSION\) >> $@
 	echo SM_RELEASE := xs\$$\(CSET_NUMBER\) >> $@
 
@@ -21,7 +21,7 @@ SM_STAMP := $(MY_OBJ_DIR)/.rpmbuild.stamp
 ERRORCODES_XML := XE_SR_ERRORCODES.xml
 SM_TESTS := $(MY_OUTPUT_DIR)/storage-manager-tests.tar
 SM_UNIT_TESTS := $(MY_OUTPUT_DIR)/smunittests.tar
-REPO := $(call hg_loc,sm)
+REPO := $(call git_loc,sm)
 SUPPORT_PACK := $(MY_OUTPUT_DIR)/borehamwood-supp-pack.iso
 BUILD := $(BUILD_NUMBER)
 
@@ -43,7 +43,8 @@ clean:
 .SECONDARY: $(SM_SRC)
 $(SM_SRC): $(SM_SOURCES)
 	echo SM_VERSION $(SM_VERSION) PLATFORM_VERSION $(PLATFORM_VERSION)
-	hg archive -p sm-$(SM_VERSION) -t tbz2 $(RPM_SOURCESDIR)/sm-$(SM_VERSION).tar.bz2
+	git --git-dir $(REPO)/.git archive --prefix=sm-$(SM_VERSION)/ \
+		--format=tar HEAD | bzip2 > $(RPM_SOURCESDIR)/sm-$(SM_VERSION).tar.bz2
 
 .SECONDARY: $(RPM_SPECSDIR)/%.spec
 $(RPM_SPECSDIR)/%.spec: *.spec.in
@@ -61,8 +62,6 @@ $(SM_STAMP): $(RPM_SRPMSDIR)/$(SM_SRPM)
 	cp $(RPM_RPMSDIR)/$(DOMAIN0_ARCH_OPTIMIZED)/sm-*.rpm $(MY_MAIN_PACKAGES)
 	# Deliberately omit the debuginfo RPM (sm-debuginfo-...)
 	rm -f $(MY_MAIN_PACKAGES)/sm-debuginfo-*.rpm
-	# sm-xencert is packaged as supp-pack. Skip it.
-	rm -f $(MY_MAIN_PACKAGES)/sm-xencert-*.rpm
 	# sm-rawhba is packaged as supp-pack. Skip it.
 	rm -f $(MY_MAIN_PACKAGES)/sm-rawhba-*.rpm
 	touch $@
@@ -80,5 +79,4 @@ $(MY_OUTPUT_DIR)/$(ERRORCODES_XML):
 	cp $(REPO)/drivers/$(ERRORCODES_XML) $@
 
 $(SUPPORT_PACK): $(SM_STAMP)
-	python setup.py --out $(dir $@) --pdn $(PRODUCT_BRAND) --pdv $(PRODUCT_VERSION) --bld $(BUILD) --spn "xencert-supp-pack" --spd "XenCert" --rxv "6.2.0" $(RPM_RPMSDIR)/$(DOMAIN0_ARCH_OPTIMIZED)/sm-xencert-*.i686.rpm
 	python setup.py --out $(dir $@) --pdn $(PRODUCT_BRAND) --pdv $(PRODUCT_VERSION) --bld $(BUILD) --spn "borehamwood-supp-pack" --spd "XenServer RawHBA implementation" --rxv "6.1.0" $(RPM_RPMSDIR)/$(DOMAIN0_ARCH_OPTIMIZED)/sm-rawhba-*.i686.rpm

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -223,39 +223,6 @@ rm -rf $RPM_BUILD_ROOT
 
 %changelog
 
-%package xencert
-Group:   System/Hypervisor
-Summary: XenCert
-
-%description xencert
-XenCert is the automated testkit for certifying storage hardware with Citrix
-XenServer.
-
-%files xencert
-"/opt/xensource/debug/XenCert/READ ME FIRST.txt"
-/opt/xensource/debug/XenCert/StorageHandler.py
-/opt/xensource/debug/XenCert/StorageHandler.pyc
-/opt/xensource/debug/XenCert/StorageHandler.pyo
-/opt/xensource/debug/XenCert/StorageHandlerUtil.py
-/opt/xensource/debug/XenCert/StorageHandlerUtil.pyc
-/opt/xensource/debug/XenCert/StorageHandlerUtil.pyo
-/opt/xensource/debug/XenCert/XenCert
-"/opt/xensource/debug/XenCert/XenCert 2 0 Guide_6 0.docx"
-/opt/xensource/debug/XenCert/XenCertCommon.py
-/opt/xensource/debug/XenCert/XenCertCommon.pyc
-/opt/xensource/debug/XenCert/XenCertCommon.pyo
-"/opt/xensource/debug/XenCert/XenCert_6 0_Verification_Results_CheckList.docx"
-/opt/xensource/debug/XenCert/blockunblockHBAPort.sh.brocade
-/opt/xensource/debug/XenCert/blockunblockHBAPort.sh.cisco
-/opt/xensource/debug/XenCert/blockunblockHBAPort.sh.qlogic
-/opt/xensource/debug/XenCert/blockunblockhbapaths-brocade
-/opt/xensource/debug/XenCert/blockunblockhbapaths-cisco
-/opt/xensource/debug/XenCert/blockunblockhbapaths-qlogic
-/opt/xensource/debug/XenCert/blockunblockiscsipaths
-/opt/xensource/debug/XenCert/blockunblockpaths
-/opt/xensource/debug/XenCert/diskdatatest
-/opt/xensource/debug/XenCert/isl_config_netapp.conf
-
 %package rawhba
 Group:   System/Hypervisor
 Summary: rawhba SR type capability


### PR DESCRIPTION
This patch fixes the build system to use the git based sm repository
instead of the mercurial one.
