### PR TITLE
CA-107099: Time out in some NFS SR operations

### DIFF
--- a/drivers/NFSSR.py
+++ b/drivers/NFSSR.py
@@ -28,6 +28,7 @@ import vhdutil
 from lock import Lock
 import cleanup
 import XenAPI
+import ipc
 
 CAPABILITIES = ["SR_PROBE","SR_UPDATE", "SR_CACHING",
                 "VDI_CREATE","VDI_DELETE","VDI_ATTACH","VDI_DETACH",
@@ -232,6 +233,18 @@ class NFSSR(FileSR.FileSR):
         util.SMlog("scanning2 (target=%s)" % target)
         dom = nfs.scan_exports(target)
         print >>sys.stderr,dom.toprettyxml()
+
+    def _checkpath(self, path, timeo=10):
+        fn = super(NFSSR, self)._checkpath
+        if timeo:
+            assert isinstance(timeo, (int, long, float))
+            abortTest = lambda:ipc.IPCFlag(self.uuid).test( \
+                    cleanup.FLAG_TYPE_ABORT)
+            return cleanup.Util.runAbortable(lambda: fn(path), True,
+                    os.path.join(self.uuid, "chkpath"), abortTest, 1, timeo)
+        else:
+            return fn(path)
+
 
 class NFSFileVDI(FileSR.FileVDI):
     def attach(self, sr_uuid, vdi_uuid):

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -140,7 +140,7 @@ class Util:
                 if resultFlag.test("success"):
                     Util.log("  Child process completed successfully")
                     resultFlag.clear("success")
-                    return
+                    return True
                 if resultFlag.test("failure"):
                     resultFlag.clear("failure")
                     raise util.SMException("Child process exited with error")


### PR DESCRIPTION
Some control-plane operations on the NFS SR may block for up to half an
hour when the NFS server is not reachable (e.g. sr-scan blocks for 30
mins when blocking the connection to the filer with iptables). Instead of
blocking for that long, wait for a time out to expire (by default 10
secs).
