### PR TITLE
CA-99235: Keep trying to remove the tag forever

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -26,6 +26,7 @@ import copy
 from lock import Lock
 import util
 import xmlrpclib
+import httplib
 import errno
 import subprocess
 import syslog as _syslog
@@ -1443,6 +1444,10 @@ class VDI(object):
             self.target = self.TargetDriver(target, driver_info)
 
         try:
+            util.fistpoint.activate_custom_fn(
+                    "blktap_activate_inject_failure",
+                    lambda: util.inject_failure())
+
             # Attach the physical node
             if self.target.has_cap("ATOMIC_PAUSE"):
                 self._attach(sr_uuid, vdi_uuid)
@@ -1452,7 +1457,23 @@ class VDI(object):
         except:
             util.SMlog("Exception in activate/attach")
             if self.tap_wanted():
-                self._remove_tag(vdi_uuid)
+                util.fistpoint.activate_custom_fn(
+                        "blktap_activate_error_handling",
+                        lambda: time.sleep(30))
+                while True:
+                    try:
+                        self._remove_tag(vdi_uuid)
+                        break
+                    except xmlrpclib.ProtocolError, e:
+                        # If there's a connection error, keep trying forever.
+                        if e.errcode == httplib.INTERNAL_SERVER_ERROR:
+                            continue
+                        else:
+                            util.SMlog('failed to remove tag: %s' % e)
+                            break
+                    except Exception, e:
+                        util.SMlog('failed to remove tag: %s' % e)
+                        break
             raise
 
         # Link result to backend/

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1166,7 +1166,9 @@ fistpoint = FistPoint( ["LVHDRT_finding_a_suitable_pair",
                         "LVHDRT_coaleaf_delay_2",
                         "LVHDRT_coaleaf_delay_3",
                         "testsm_clone_allow_raw",
-                        "xenrt_default_vdi_type_legacy"] )
+                        "xenrt_default_vdi_type_legacy",
+                        "blktap_activate_inject_failure",
+                        "blktap_activate_error_handling"] )
 
 def set_dirty(session, sr):
     try:
@@ -1598,3 +1600,5 @@ def splitXmlText( xmlData, segmentLen = DEFAULT_SEGMENT_LEN, showContd = False )
 
     return returnData
 
+def inject_failure():
+    raise Exception('injected failure')


### PR DESCRIPTION
In the error handling path of VDI.activate, if the connection with the
master is lost, the slave cannot remove the tag from sm-config. When the
connection is restored, the VDI is left in undefined state. To avoid
this we keep trying to remove the tag until we succeed (the connection
with the host has been restored).
