### PR TITLE
CA-110509: Impossible to create LVHD over iSCSI SRs with more then one i...

### DIFF
--- a/drivers/ISCSISR.py
+++ b/drivers/ISCSISR.py
@@ -630,7 +630,9 @@ class ISCSISR(SR.SR):
             subentry.appendChild(textnode)
 
             try:
-                (addr, port) = iscsilib.parse_IP_port(address)
+                # We always expect a port so this holds
+                # regardless of IP version
+                (addr, port) = address.rsplit(':', 1)
             except:
                 addr = address
                 port = DEFAULT_PORT


### PR DESCRIPTION
...SCSI target IP

When passing multiples IPs on the target list, when printing entries for the
wildcard option we compose a string this way
IP1,IP2,..,IPn:PORT
The IPs can be in IPv4 or IPv6 format but the last colon is always
a delimiter for the port.
The parse_IP_port function is not suitable in this case (it needs to be modified, anyway),
so we simply split the PORT from the rest of the string: the latter is kept as it is.
