### PR TITLE
ISCSISR: force_tapdisk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 .pc
 *~
 *.orig

--- a/README.md
+++ b/README.md
@@ -1,6 +1,28 @@
 Storage Manager for XenServer
 =============================
 
-This repository contains the code which forms the Stroage Management layer for XenSever. It consists of a series of "plug-ins" to xapi (the Xen management layer) which are written primarily in python.
+This repository contains the code which forms the Stroage Management layer for
+XenSever. It consists of a series of "plug-ins" to xapi (the Xen management
+layer) which are written primarily in python.
 
+## Run Python unit tests
 
+### Install prerequisites
+
+On an Ubuntu 12.04 64 bit system, run:
+
+    sudo bash tools/install_prerequisites.sh
+
+### Setup Virtual Environment
+
+This script will create a new python virtualenv, install the dependencies to
+it, compile the required python files for `snapwatchd`:
+
+    tools/setup_env.sh
+
+### Run the Tests
+
+This script activates the virtual environment, and runs the tests with 
+`nosetests`. It also tweaks `PYTHONPATH`, so python finds `xslib.py`
+
+    tools/run_tests.sh

--- a/drivers/ISCSISR.py
+++ b/drivers/ISCSISR.py
@@ -36,7 +36,9 @@ CONFIGURATION = [ [ 'target', 'IP address or hostname of the iSCSI target (requi
                   [ 'incoming_chapuser', 'The incoming username to be used during bi-directional CHAP authentication (optional)' ], \
                   [ 'incoming_chappassword', 'The incoming password to be used during bi-directional CHAP authentication (optional)' ], \
                   [ 'port', 'The network port number on which to query the target (optional)' ], \
-                  [ 'multihomed', 'Enable multi-homing to this target, true or false (optional, defaults to same value as host.other_config:multipathing)' ] ]
+                  [ 'multihomed', 'Enable multi-homing to this target, true or false (optional, defaults to same value as host.other_config:multipathing)' ],
+                  [ 'force_tapdisk', 'Force use of tapdisk, true or false (optional, defaults to false)'],
+]
 
 DRIVER_INFO = {
     'name': 'iSCSI',
@@ -60,6 +62,11 @@ ISCSI_PROCNAME = "iscsi_tcp"
 
 class ISCSISR(SR.SR):
     """ISCSI storage repository"""
+
+    @property
+    def force_tapdisk(self):
+        return self.dconf.get('force_tapdisk', 'false') == 'true'
+
     def handles(type):
         if type == "iscsi":
             return True
@@ -97,7 +104,10 @@ class ISCSISR(SR.SR):
                 
 
     def load(self, sr_uuid):
-        self.sr_vditype = 'phy'
+        if self.force_tapdisk:
+            self.sr_vditype = 'aio'
+        else:
+            self.sr_vditype = 'phy'
         self.discoverentry = 0
         self.default_vdi_visibility = False
         

--- a/tests/test_ISCSISR.py
+++ b/tests/test_ISCSISR.py
@@ -1,0 +1,84 @@
+import unittest
+import ISCSISR
+import mock
+import xs_errors
+import os
+
+
+class TestBase(unittest.TestCase):
+    """ Provides errorcodes.xml, so exceptions are sensible """
+
+    def setUp(self):
+        self._xmldefs = xs_errors.XML_DEFS
+        xs_errors.XML_DEFS = os.path.join(
+            os.path.dirname(__file__), 'XE_SR_ERRORCODES.xml')
+
+    def tearDown(self):
+        xs_errors.XML_DEFS = self._xmldefs
+
+
+class NonLoadingISCSISR(ISCSISR.ISCSISR):
+    def load(self, sr_uuid):
+        pass
+
+
+class TestForceTapDiskConfig(TestBase):
+
+    def _get_iscsi_sr(self, dconf=None):
+        srcmd = mock.Mock()
+        srcmd.dconf = dconf or {}
+        srcmd.params = {
+            'command': 'some_command'
+        }
+
+        iscsisr = NonLoadingISCSISR(srcmd, None)
+        return iscsisr
+
+    def test_default_value(self):
+        iscsi_sr = self._get_iscsi_sr()
+
+        self.assertEquals(False, iscsi_sr.force_tapdisk)
+
+    def test_set_to_true(self):
+        iscsi_sr = self._get_iscsi_sr({
+            'force_tapdisk': 'true'
+        })
+
+        self.assertEquals(True, iscsi_sr.force_tapdisk)
+
+
+class NonInitingISCSISR(ISCSISR.ISCSISR):
+    def __init__(self, extra_dconf=None):
+        self.mpath = "false"
+        self.dconf = {
+            'target': 'target',
+            'localIQN': 'localIQN',
+            'targetIQN': 'targetIQN'
+        }
+
+        self.dconf.update(extra_dconf or {})
+
+
+class TestVdiTypeSetting(TestBase):
+
+    @mock.patch('ISCSISR.iscsilib.discovery')
+    @mock.patch('ISCSISR.iscsilib.ensure_daemon_running_ok')
+    @mock.patch('ISCSISR.util._testHost')
+    @mock.patch('ISCSISR.util._convertDNS')
+    def load_iscsi_sr(self, convertDNS, testHost, ensure_daemon_running_ok,
+                      discovery, iscsi_sr):
+        iscsi_sr.load(None)
+
+    def test_default_vdi_type(self):
+        iscsi_sr = NonInitingISCSISR()
+
+        self.load_iscsi_sr(iscsi_sr=iscsi_sr)
+
+        self.assertEquals('phy', iscsi_sr.sr_vditype)
+
+    def test_vdi_type_modified_by_force_tapdisk(self):
+        iscsi_sr = NonInitingISCSISR(extra_dconf=dict(force_tapdisk='true'))
+
+        self.load_iscsi_sr(iscsi_sr=iscsi_sr)
+
+        self.assertEquals('aio', iscsi_sr.sr_vditype)

--- a/tools/install_prerequisites.sh
+++ b/tools/install_prerequisites.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eux
+
+# Get apt-add-repository
+apt-get -qy install python-software-properties
+
+# Add deadsnakes for ancient python packages
+apt-add-repository ppa:fkrull/deadsnakes -y
+
+apt-get update
+
+# Install python 2.4
+apt-get -qy install python2.4-dev python-distribute-deadsnakes
+
+# Get virtualenv
+easy_install-2.4 virtualenv==1.7.2
+
+# Install other dependences
+apt-get -qy install swig libxen-dev make

--- a/tools/run_tests.sh
+++ b/tools/run_tests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -eux
+
+SMROOT=$(cd $(dirname $0) && cd .. && pwd)
+ENVDIR="$SMROOT/.env"
+
+set +u
+. "$ENVDIR/bin/activate"
+set -u
+
+(
+    cd "$SMROOT"
+    PYTHONPATH="$SMROOT/snapwatchd:$SMROOT/drivers/" nosetests tests/test_ISCSISR.py
+)

--- a/tools/setup_env.sh
+++ b/tools/setup_env.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eux
+
+SMROOT=$(cd $(dirname $0) && cd .. && pwd)
+ENVDIR="$SMROOT/.env"
+
+virtualenv-2.4 --no-site-packages "$ENVDIR"
+
+set +u
+. "$ENVDIR/bin/activate"
+set -u
+
+#pip install pep8==1.2
+#pep8 --ignore=W601,E501,E401,W603,E711 drivers/ISCSISR.py
+
+# 1.3 is not working
+pip install nose==1.2.1
+pip install xenapi
+pip install mock
+
+# build xslib.py
+# I need -fPIC otherwise I get "relocation R_X86_64_32 against" type errors
+make -C "$SMROOT/snapwatchd" CFLAGS="-O2 -I/usr/include/python2.4/ -I/usr/include -shared -fPIC"


### PR DESCRIPTION
Serving the iSCSI target from a domU for a raw iSCSI was not working.
This fix adds a configuration parameter to the iSCSI SR to enforce the
use of tapdisk.
