### PR TITLE
CA-107572: VM migration failed.Catch VDI not found exception and discard...

### DIFF
--- a/drivers/SR.py
+++ b/drivers/SR.py
@@ -555,7 +555,13 @@ class ScanRecord:
         for location in self.gone:
             vdi = self.get_xenapi_vdi(location)
             util.SMlog("Forgetting VDI with location=%s uuid=%s" % (util.to_plain_string(vdi['location']), vdi['uuid']))
-            self.sr.forget_vdi(vdi['uuid'])
+            try:
+                self.sr.forget_vdi(vdi['uuid'])
+            except XenAPI.Failure, e:
+                if e.details == "HANDLE_INVALID" or e.details == "UUID_INVALID":
+                   util.SMlog("VDI %s not found, ignoring exception" % uuid)
+                else:
+                   raise
 
     def synchronise_existing(self):
         """Update existing XenAPI records"""


### PR DESCRIPTION
CA-107572: VM migration failed because XAPI throw VDI not found exception. The VDI was already removed, the fix will catch the exception and discard it.
