### PR TITLE
CA-105130: udev does not automatically refresh dev/disk/by-id

### DIFF
--- a/drivers/mpath_dmp.py
+++ b/drivers/mpath_dmp.py
@@ -172,6 +172,13 @@ def map_by_scsibus(sid,npaths=0):
     __map_explicit(devices)
     
 def refresh(sid,npaths):
+    # Fix udev bug (?): make sure it updates /dev/disk/by-id
+    # Trigger the old way, if possible
+    if os.path.exists("/sbin/udevtrigger"):
+        util.pread2(["/sbin/udevtrigger"]) 
+    else:
+        util.pread2(["/sbin/udevadm","trigger"])
+
     # Refresh the multipath status
     util.SMlog("Refreshing LUN %s" % sid)
     if len(sid):


### PR DESCRIPTION
udev maintains symlinks into /dev/disk/by-id refreshing to
the latest available path to the same disk.
When the last added path is removed, the link is removed as
well, instead of being just updated to the previous path.

Recent versions of udev (e.g. in CentOS 6.4) do not show
this behaviour but our current version (095) needs to be triggered.

Signed-off-by: Germano Percossi germano.percossi@citrix.com
