### PR TITLE
CA-113322: avoid using realpath wrt the new devmapper convention

### DIFF
--- a/drivers/vhdutil.py
+++ b/drivers/vhdutil.py
@@ -177,8 +177,8 @@ def hasParent(path):
     return vhd_type == "Differencing"
 
 def setParent(path, parentPath, parentRaw):
-    realPPath = util.get_real_path(parentPath)
-    cmd = [VHD_UTIL, "modify", OPT_LOG_ERR, "-p", realPPath, "-n", path]
+    normpath = os.path.normpath(parentPath)
+    cmd = [VHD_UTIL, "modify", OPT_LOG_ERR, "-p", normpath, "-n", path]
     if parentRaw:
         cmd.append("-m")
     ioretry(cmd)


### PR DESCRIPTION
Due to the change on dev mapper linking/naming conventions, we should
avoid using realpath to chase to the final path. Also, we can now
rely on vhd-util itself to canonicalize the path.

Signed-off-by: Zheng Li zheng.li@eu.citrix.com
