### PR TITLE
CA-107356: Fix tapdisk unpause issue in case of VM migration failed.

### DIFF
--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -1452,16 +1452,15 @@ class LVHDVDI(VDI.VDI):
         if not blktap2.VDI.tap_pause(self.session, sr_uuid, vdi_uuid):
             raise util.SMException("failed to pause VDI %s" % vdi_uuid)
 
-        temp = None
+        snapResult = None
         try:
-            temp = self._snapshot(snapType)
+            snapResult = self._snapshot(snapType)
         except:
-            util.SMlog("Caught exception in snapshot, make sure secondary device set to null to unpause tapdisk")
             blktap2.VDI.tap_unpause(self.session, sr_uuid, vdi_uuid, None)
             raise
             
         blktap2.VDI.tap_unpause(self.session, sr_uuid, vdi_uuid, secondary)
-        return temp
+        return snapResult
 
     def clone(self, sr_uuid, vdi_uuid):
         return self._snapshot(self.SNAPSHOT_DOUBLE, True)


### PR DESCRIPTION
VDI has driver name set to nbd in case VM migration failed. While unpause tapdisk, it was always
using mirror driver name. In a snapshot failure scenario, the fix will pass None as driver name
to unpause tapdisk.

Signed-off-by: Sisimon Soman sisimon.soman@citrix.com
