### PR TITLE
CP-5830: Productise removal of lvm2-master-mode.patch

### DIFF
--- a/drivers/SR.py
+++ b/drivers/SR.py
@@ -28,6 +28,7 @@ import copy, os
 MOUNT_BASE = '/var/run/sr-mount'
 DEFAULT_TAP = 'vhd'
 TAPDISK_UTIL = '/usr/sbin/td-util'
+MASTER_LVM_CONF = '/etc/lvm/master'
 
 # LUN per VDI key for XenCenter
 LUNPERVDI = "LUNperVDI"
@@ -106,6 +107,10 @@ class SR(object):
 
             if 'sr_ref' in self.srcmd.params:
                 self.sr_ref = self.srcmd.params['sr_ref']
+
+	    if 'device_config' in self.srcmd.params:
+                if self.dconf.get("SRmaster") == "true":
+                    os.environ['LVM_SYSTEM_DIR'] = MASTER_LVM_CONF
 
         except Exception, e:
             raise e

--- a/drivers/lvutil.py
+++ b/drivers/lvutil.py
@@ -352,7 +352,7 @@ def createVG(root, vgname):
                 pass
             raise xs_errors.XenError('LVMGroupCreate')
     try:
-        cmd = [CMD_VGCHANGE, "-an", "--master", vgname]
+        cmd = [CMD_VGCHANGE, "-an", vgname]
         util.pread2(cmd)
     except util.CommandException, inst:
         raise xs_errors.XenError('LVMUnMount', \
@@ -394,7 +394,7 @@ def setActiveVG(path, active):
     val = "n"
     if active:
         val = "y"
-    cmd = [CMD_VGCHANGE, "-a" + val, "--master", path]
+    cmd = [CMD_VGCHANGE, "-a" + val, path]
     text = util.pread2(cmd)
 
 def create(name, size, vgname, tag = None, activate = True):

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -28,6 +28,11 @@ rm -rf $RPM_BUILD_ROOT
 
 %post
 [ ! -x /sbin/chkconfig ] || chkconfig --add mpathroot
+cp /etc/lvm/lvm.conf /etc/lvm/lvm.conf.orig
+mkdir /etc/lvm/master
+cp /etc/lvm/lvm.conf /etc/lvm/master/lvm.conf
+sed -i 's/metadata_read_only =.*/metadata_read_only = 1/' /etc/lvm/lvm.conf
+sed -i 's/metadata_read_only =.*/metadata_read_only = 0/' /etc/lvm/master/lvm.conf
 
 %files
 %defattr(-,root,root,-)
@@ -229,7 +234,6 @@ rm -rf $RPM_BUILD_ROOT
 /opt/xensource/sm/xs_errors.pyc
 /opt/xensource/sm/xs_errors.pyo
 /sbin/mpathutil
-
 
 %changelog
 


### PR DESCRIPTION
Removed the --master switch from lvm commands. We now use two separate lvm
conf files for master and slave nodes. The slave conf file is the default and has metadata_read_only=1. When a node is chosen as master, default conf file is overridden through an environment variable. 
