### PR TITLE
CA-116958: "VM.copy locking failed" error observed on trunk

### DIFF
--- a/drivers/lvutil.py
+++ b/drivers/lvutil.py
@@ -58,6 +58,9 @@ LVM_SIZE_INCREMENT = 4 * 1024 * 1024
 LV_TAG_HIDDEN = "hidden"
 LVM_FAIL_RETRIES = 10
 
+MASTER_LVM_CONF = '/etc/lvm/master'
+DEF_LVM_CONF = '/etc/lvm'
+
 class LVInfo:
     name = ""
     size = 0
@@ -479,12 +482,16 @@ def activateNoRefcount(path, refresh):
     if not _checkActive(path):
         raise util.CommandException(-1, str(cmd), "LV not activated")
     if refresh:
+        # Override slave mode lvm.conf for this command
+        os.environ['LVM_SYSTEM_DIR'] = MASTER_LVM_CONF
         cmd = [CMD_LVCHANGE, "--refresh", path]
         text = util.pread2(cmd)
         mapperDevice = path[5:].replace("-", "--").replace("/", "-")
         cmd = [CMD_DMSETUP, "table", mapperDevice]
         ret = util.pread(cmd)
         util.SMlog("DM table for %s: %s" % (path, ret.strip()))
+        # Restore slave mode lvm.conf
+        os.environ['LVM_SYSTEM_DIR'] = DEF_LVM_CONF
 
 def deactivateNoRefcount(path):
     # LVM has a bug where if an "lvs" command happens to run at the same time 


### PR DESCRIPTION
Override slave mode lvm.conf for lvchange --refresh command on slaves

Signed-off-by: Chandrikas Srinivasan chandrika.srinivasan@citrix.com
