### PR TITLE
CA-116545: SR detach could fail during a Find Open process check

### DIFF
--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1256,7 +1256,7 @@ def findRunningProcessOrOpenFile(name, process = True):
                     # Ignore pid that are no longer valid
                     continue
                 else:
-                    raise Exception(str(e))
+                    raise
             
             for file in files:
                 try:


### PR DESCRIPTION
This could happen if one pid, out of a list of pids, cease to exist.
Ignoring the error helps us move forward through the list checking
for any pid / file handles
