### PR TITLE
[CP-6333][CP-6334]: rm dm-multipath-dm-event, dm-multipath-disable-udev-...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ SM_LIBS += lcache
 SM_LIBS += resetvdis
 SM_LIBS += B_util
 
+UDEV_RULES = 40-multipath
+
 CRON_JOBS += ringwatch
 
 SM_XML := XE_SR_ERRORCODES
@@ -67,6 +69,7 @@ MASTER_SCRIPT_DEST := /etc/xensource/master.d/
 PLUGIN_SCRIPT_DEST := /etc/xapi.d/plugins/
 LIBEXEC := /opt/xensource/libexec/
 CRON_DEST := /etc/cron.d/
+UDEV_RULES_DIR := /etc/udev/rules.d/
 
 SM_STAGING := $(DESTDIR)
 SM_STAMP := $(MY_OBJ_DIR)/.staging_stamp
@@ -112,6 +115,7 @@ install: precheck
 	mkdir -p $(SM_STAGING)
 	$(call mkdir_clean,$(SM_STAGING))
 	mkdir -p $(SM_STAGING)$(SM_DEST)
+	mkdir -p $(SM_STAGING)$(UDEV_RULES_DIR)
 	mkdir -p $(SM_STAGING)$(DEBUG_DEST)
 	mkdir -p $(SM_STAGING)$(BIN_DEST)
 	mkdir -p $(SM_STAGING)$(MASTER_SCRIPT_DEST)
@@ -120,6 +124,9 @@ install: precheck
 	for i in $(SM_PY_FILES); do \
 	  install -m 755 $$i $(SM_STAGING)$(SM_DEST); \
 	done
+	for i in $(UDEV_RULES); do \
+	  install -m 644 multipath/$$i.rules \
+	    $(SM_STAGING)$(UDEV_RULES_DIR); done
 	for i in $(SM_XML); do \
 	  install -m 755 drivers/$$i.xml \
 	    $(SM_STAGING)$(SM_DEST); done

--- a/drivers/mpathcount.py
+++ b/drivers/mpathcount.py
@@ -104,9 +104,12 @@ def match_dmpLUN(s):
 
 def match_pathup(s):
     s = re.sub('\]',' ',re.sub('\[','',s)).split()
-    dm_status = s[-1]
-    path_status = s[-2]
-    for val in [dm_status, path_status]:
+    # The new multipath has a different output. Fixed it
+    dm_status = s[-2]
+    path_status = s[-3]
+    # path_status is more reliable, at least for failures initiated or spotted by multipath
+    # To be tested for failures during high I/O when dm should spot errors first
+    for val in [path_status]:
         if val in ['faulty','shaky','failed']:
             return False
     return True

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -229,6 +229,7 @@ rm -rf $RPM_BUILD_ROOT
 /opt/xensource/sm/xs_errors.pyc
 /opt/xensource/sm/xs_errors.pyo
 /sbin/mpathutil
+%config /etc/udev/rules.d/40-multipath.rules
 
 
 %changelog

--- a/multipath/40-multipath.rules
+++ b/multipath/40-multipath.rules
@@ -1,0 +1,12 @@
+SUBSYSTEM!="block", GOTO="end_mpath"
+RUN+="socket:/org/kernel/dm/multipath_event"
+KERNEL!="dm-*", GOTO="end_mpath"
+ACTION=="add", PROGRAM=="/bin/bash -c '/sbin/dmsetup info -c -o name --noheadings -j %M -m %m | /bin/grep VG_XenStorage'", OPTIONS+="ignore_device"
+ACTION=="add", PROGRAM=="/bin/bash -c '/sbin/dmsetup info -c -o name --noheadings -j %M -m %m | /bin/grep XSLocalEXT'", OPTIONS+="ignore_device"
+KERNEL=="dm-*", ACTION=="add", PROGRAM=="/sbin/dmsetup info -c -o name --noheadings -j %M -m %m", RESULT=="?*", SYMLINK+="disk/by-scsid/%c/mapper"
+ACTION=="change", PROGRAM!="/sbin/dmsetup info -c --noheadings -j %M -m %m", GOTO="end_mpath"
+PROGRAM!="/sbin/dmsetup info -c -o uuid,name --separator ' ' --noheadings -j %M -m %m", GOTO="end_mpath"
+RESULT!="mpath-*", GOTO="end_mpath"
+# ENV is necessary otherwise the child process of mpathcount cannot find multipathd executable
+ACTION=="change", ENV{PATH}="/sbin:/bin:/usr/sbin:/usr/bin", RUN+="/opt/xensource/sm/mpathcount.py %c{2}"
+LABEL="end_mpath"


### PR DESCRIPTION
...rules

This patch is the counterpart of 2 patches removed in
dm-multipath (formerly dm-multipath in guest-packages.hg):
- dm-multipath-disable-udev-rules
- dm-multipath-dm-event

This patch basically does the following:
- ship and override multipath udev rules from sm RPM
- add rules to invoke mpathcount from udev

Note: for udev to catch the relevant events, the kernel must have
      DM_UEVENT enabled

Signed-off-by: Germano Percossi germano.percossi@citrix.com
