### PR TITLE
CP-6335: Removal of dm-multipath-init patch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ SM_LIBS += resetvdis
 SM_LIBS += B_util
 
 UDEV_RULES = 40-multipath
+MPATH_DAEMON = sm-multipath
 
 CRON_JOBS += ringwatch
 
@@ -70,6 +71,7 @@ PLUGIN_SCRIPT_DEST := /etc/xapi.d/plugins/
 LIBEXEC := /opt/xensource/libexec/
 CRON_DEST := /etc/cron.d/
 UDEV_RULES_DIR := /etc/udev/rules.d/
+INIT_DIR := /etc/rc.d/init.d/
 
 SM_STAGING := $(DESTDIR)
 SM_STAMP := $(MY_OBJ_DIR)/.staging_stamp
@@ -116,6 +118,7 @@ install: precheck
 	$(call mkdir_clean,$(SM_STAGING))
 	mkdir -p $(SM_STAGING)$(SM_DEST)
 	mkdir -p $(SM_STAGING)$(UDEV_RULES_DIR)
+	mkdir -p $(SM_STAGING)$(INIT_DIR)
 	mkdir -p $(SM_STAGING)$(DEBUG_DEST)
 	mkdir -p $(SM_STAGING)$(BIN_DEST)
 	mkdir -p $(SM_STAGING)$(MASTER_SCRIPT_DEST)
@@ -124,6 +127,8 @@ install: precheck
 	for i in $(SM_PY_FILES); do \
 	  install -m 755 $$i $(SM_STAGING)$(SM_DEST); \
 	done
+	install -m 755 multipath/$(MPATH_DAEMON) \
+	  $(SM_STAGING)/$(INIT_DIR)
 	for i in $(UDEV_RULES); do \
 	  install -m 644 multipath/$$i.rules \
 	    $(SM_STAGING)$(UDEV_RULES_DIR); done

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -28,6 +28,10 @@ rm -rf $RPM_BUILD_ROOT
 
 %post
 [ ! -x /sbin/chkconfig ] || chkconfig --add mpathroot
+[ ! -x /sbin/chkconfig ] || chkconfig --add sm-multipath
+
+%preun
+[ ! -x /sbin/chkconfig ] || chkconfig --del sm-multipath
 
 %files
 %defattr(-,root,root,-)
@@ -229,6 +233,7 @@ rm -rf $RPM_BUILD_ROOT
 /opt/xensource/sm/xs_errors.pyc
 /opt/xensource/sm/xs_errors.pyo
 /sbin/mpathutil
+/etc/rc.d/init.d/sm-multipath
 %config /etc/udev/rules.d/40-multipath.rules
 
 

--- a/multipath/sm-multipath
+++ b/multipath/sm-multipath
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+# sm-multipath	 Support function for multipath in SM
+#
+# chkconfig: 2345 16 77
+# description: Create proper symlinks in /dev/ if root is multipathed
+
+### BEGIN INIT INFO
+# Provides: sm-multipath
+# Required-Start:
+# Required-Stop:
+# Default-Start:
+# Default-Stop:
+# Short-Description: Support function for multipath in SM
+# Description: Create proper symlinks in /dev/ if
+#         root is multipathed
+### END INIT INFO
+
+DAEMON=/sbin/multipathd
+prog=sm-multipath
+initdir=/etc/rc.d/init.d
+
+. $initdir/functions
+
+RETVAL=0
+
+#
+# See how we were called.
+#
+
+start() {
+	test -x $DAEMON || exit 5
+	echo -n $"Multipath check for root device: "
+	$DAEMON -k"show top" &>/dev/null
+	RETVAL=$?
+	[ $RETVAL -eq 0 ] || failure || exit 0
+	success
+
+	# Create an mpInuse symlink for the root device if that is multipath.
+	DEVICE_MAPPER_MAJOR=$(sed -ne 's/^\([0-9]\+\) device-mapper$/\1/p' /proc/devices)
+	DEVICE_MAPPER_MAJOR_HEX=$(printf "%x" ${DEVICE_MAPPER_MAJOR})
+	ROOT_PART_MAJOR=$(stat --format=%t /dev/root)
+	if [ "$ROOT_PART_MAJOR" == "$DEVICE_MAPPER_MAJOR_HEX" ] ; then
+		ROOT_PART_MINOR=$(stat --format=%T /dev/root)
+		ROOT_PART_SLAVE=$(/bin/ls /sys/block/dm-$ROOT_PART_MINOR/slaves)
+		ROOT_DISK_MINOR=${ROOT_PART_SLAVE#dm-}
+		MPATH_NODES="$(dmsetup ls --target multipath --exec ls)"
+		for n in $MPATH_NODES ; do
+			NODE_MINOR="$(stat --format=%T $n)"
+			if [ "$ROOT_DISK_MINOR" = "$NODE_MINOR" ] ; then
+				mkdir -p /dev/disk/mpInuse
+				ln -sf $n /dev/disk/mpInuse
+			fi
+		done
+	fi
+
+	echo
+}
+
+stop() {
+	echo -n $"Stopping $prog daemon: "
+	success
+	echo
+}
+
+restart() {
+	stop
+	start
+}
+
+case "$1" in
+start)
+	start
+	;;
+stop)
+	stop
+	;;
+restart)
+	restart
+	;;
+*)
+	echo $"Usage: $0 {start|stop|status|restart|condrestart|reload}"
+	RETVAL=2
+esac
+
+exit $RETVAL


### PR DESCRIPTION
This functionality has stopped being a patch to upstream
multipath and it is shipped in its own startup script
provided by sm RPM

Signed-off-by: Germano Percossi germano.percossi@citrix.com
