### PR TITLE
CA-118899: Explicit encoding of iSCSI target name to enable support for UTF-8 iSCSI target names.

### DIFF
--- a/drivers/ISCSISR.py
+++ b/drivers/ISCSISR.py
@@ -183,7 +183,8 @@ class ISCSISR(SR.SR):
             self._scan_IQNs()
             raise xs_errors.XenError('ConfigTargetIQNMissing')
 
-        self.targetIQN = self.dconf['targetIQN']
+        # CA-118899: Ensure that the targetIQN is encoded in UTF-8 format.
+        self.targetIQN = unicode(self.dconf['targetIQN']).encode('utf-8')
         self.attached = False
         try:
             self.attached = iscsilib._checkTGT(self.targetIQN)


### PR DESCRIPTION
Having investigated whether SM supports UTF-8 characters in the iSCSI target name, I've identified a bug in how we handle the 'targetIQN' string passed into the ISCSI class.

I believe fixing the encoding at this point, rather than at the various uses of the string, is the most efficient fix - but equally, the user of such a string could be educated to ensure that the strings it is compiling for re (or other) are of the appropriate format.

I've tested that this fix allows me to add, use, destroy, forget SRs with UTF-8 chars in the target iSCSI name.

Signed-off-by: Rob Dobson rob@rdobson.co.uk
