### PR TITLE
CA-116160: Python exception in HBA SR create.

### DIFF
--- a/drivers/HBASR.py
+++ b/drivers/HBASR.py
@@ -65,7 +65,7 @@ class HBASR(SR.SR):
             dict = devscan.adapters(filterstr=self.type)
             self.hbadict = dict['devs']
             self.hbas = dict['adt']
-            if len(self.hbas.iterkeys()):
+            if len(self.hbas):
                 self.attached = True
                 self.devs = scsiutil.cacheSCSIidentifiers()
 


### PR DESCRIPTION
len() on dictionary iterkeys is not valid in Python 2.6.
Replaced it with len() directly on the dictionary.

Signed-off-by: Chandrika Srinivasan chandrika.srinivasan@citrix.com
