### PR TITLE
CP-5830: Productise removal of lvm2-master-mode.patch

### DIFF
--- a/drivers/SR.py
+++ b/drivers/SR.py
@@ -28,6 +28,7 @@ import copy, os
 MOUNT_BASE = '/var/run/sr-mount'
 DEFAULT_TAP = 'vhd'
 TAPDISK_UTIL = '/usr/sbin/td-util'
+MASTER_LVM_CONF = '/etc/lvm/master'
 
 # LUN per VDI key for XenCenter
 LUNPERVDI = "LUNperVDI"
@@ -106,6 +107,10 @@ class SR(object):
 
             if 'sr_ref' in self.srcmd.params:
                 self.sr_ref = self.srcmd.params['sr_ref']
+
+	    if 'device_config' in self.srcmd.params:
+                if self.dconf.get("SRmaster") == "true":
+                    os.environ['LVM_SYSTEM_DIR'] = MASTER_LVM_CONF
 
         except Exception, e:
             raise e

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -29,9 +29,18 @@ rm -rf $RPM_BUILD_ROOT
 %post
 [ ! -x /sbin/chkconfig ] || chkconfig --add mpathroot
 [ ! -x /sbin/chkconfig ] || chkconfig --add sm-multipath
+[ -f /etc/lvm/lvm.conf.orig ] || cp /etc/lvm/lvm.conf /etc/lvm/lvm.conf.orig || exit $?
+[ -d /etc/lvm/master ] || mkdir /etc/lvm/master || exit $?
+cp -f /etc/lvm/lvm.conf /etc/lvm/master/lvm.conf || exit $?
+sed -i 's/metadata_read_only =.*/metadata_read_only = 1/' /etc/lvm/lvm.conf || exit $?
+sed -i 's/metadata_read_only =.*/metadata_read_only = 0/' /etc/lvm/master/lvm.conf || exit $?
 
 %preun
 [ ! -x /sbin/chkconfig ] || chkconfig --del sm-multipath
+
+%postun
+[ ! -d /etc/lvm/master ] || rm -Rf /etc/lvm/master || exit $?
+cp -f /etc/lvm/lvm.conf.orig /etc/lvm/lvm.conf || exit $?
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
Removed the --master switch from lvm commands. We now use two separate
lvm conf files for master and slave nodes. Appropriate conf file is
chosen through an environment variable.

Signed-off-by: Chandrika Srinivasan chandrika.srinivasan@citrix.com
