### PR TITLE
Fix link of snapwatchd on Ubuntu raring

### DIFF
--- a/snapwatchd/Makefile
+++ b/snapwatchd/Makefile
@@ -9,7 +9,7 @@ PYTHON_INCLUDE_DEFAULT := $(dir $(shell find /usr/include/ -maxdepth 2 -path \*/
 PYTHON_INCLUDE ?= $(PYTHON_INCLUDE_DEFAULT)
 
 CFLAGS ?= -O2
-CFLAGS += -I$(PYTHON_INCLUDE) -I$(XS_INCLUDE)
+CFLAGS += -I$(PYTHON_INCLUDE) -I$(XS_INCLUDE) -fPIC
 
 SWIG ?= swig
 


### PR DESCRIPTION
snapwatchd fails to link a shared .so with -shared:

  /usr/bin/ld: xslib.o: relocation R_X86_64_32 against `.rodata.str1.1'
  can not be used when making a shared object
  xslib.o: could not read symbols: Bad value

We need to explicitly compile our objects as position-independent
code with -fPIC

Signed-off-by: David Scott dave.scott@eu.citrix.com
