### PR TITLE
 CP-5818: Productise removal of lvm2-lvcreate-inactive-flag.patch

### DIFF
--- a/drivers/lvmcache.py
+++ b/drivers/lvmcache.py
@@ -97,11 +97,11 @@ class LVMCache:
     # lvutil functions
     #
     @lazyInit
-    def create(self, lvName, size, tag = None, activate = True):
-        lvutil.create(lvName, size, self.vgName, tag, activate)
+    def create(self, lvName, size, tag = None):
+        lvutil.create(lvName, size, self.vgName, tag)
         lvInfo = LVInfo(lvName)
         lvInfo.size = size
-        lvInfo.active = activate
+        lvInfo.active = True
         self.lvs[lvName] = lvInfo
         if tag:
             self._addTag(lvName, tag)

--- a/drivers/lvutil.py
+++ b/drivers/lvutil.py
@@ -397,13 +397,11 @@ def setActiveVG(path, active):
     cmd = [CMD_VGCHANGE, "-a" + val, "--master", path]
     text = util.pread2(cmd)
 
-def create(name, size, vgname, tag = None, activate = True):
+def create(name, size, vgname, tag = None):
     size_mb = size / 1024 / 1024
     cmd = [CMD_LVCREATE, "-n", name, "-L", str(size_mb), vgname]
     if tag:
         cmd.extend(["--addtag", tag])
-    if not activate:
-        cmd.extend(["--inactive", "--zero=n"])
     util.pread2(cmd)
 
 def remove(path):


### PR DESCRIPTION
Snapshot and leaf coalesce use temp files with additional info like
parent UUID in the name of the file. Since this name is too long and
not liked my mapper, the file is created in an inactive mode. This
patch changes the logic to create a temp file with a shorter name
and writes additional informaton into the file. Inactive flag for
lvcreate is no longer required.

Signed-off-by: Chandrika Srinivasan chandrika.srinivasan@citrix.com
