### PR TITLE
CP-6336: Removal of dm-multipath-conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ SM_LIBS += B_util
 
 UDEV_RULES = 40-multipath
 MPATH_DAEMON = sm-multipath
+MPATH_CONF = multipath.conf
 
 CRON_JOBS += ringwatch
 
@@ -72,6 +73,7 @@ LIBEXEC := /opt/xensource/libexec/
 CRON_DEST := /etc/cron.d/
 UDEV_RULES_DIR := /etc/udev/rules.d/
 INIT_DIR := /etc/rc.d/init.d/
+MPATH_CONF_DIR := /etc/multipath.xenserver/
 
 SM_STAGING := $(DESTDIR)
 SM_STAMP := $(MY_OBJ_DIR)/.staging_stamp
@@ -119,6 +121,7 @@ install: precheck
 	mkdir -p $(SM_STAGING)$(SM_DEST)
 	mkdir -p $(SM_STAGING)$(UDEV_RULES_DIR)
 	mkdir -p $(SM_STAGING)$(INIT_DIR)
+	mkdir -p $(SM_STAGING)$(MPATH_CONF_DIR)
 	mkdir -p $(SM_STAGING)$(DEBUG_DEST)
 	mkdir -p $(SM_STAGING)$(BIN_DEST)
 	mkdir -p $(SM_STAGING)$(MASTER_SCRIPT_DEST)
@@ -127,6 +130,8 @@ install: precheck
 	for i in $(SM_PY_FILES); do \
 	  install -m 755 $$i $(SM_STAGING)$(SM_DEST); \
 	done
+	install -m 644 multipath/$(MPATH_CONF) \
+	  $(SM_STAGING)/$(MPATH_CONF_DIR)
 	install -m 755 multipath/$(MPATH_DAEMON) \
 	  $(SM_STAGING)/$(INIT_DIR)
 	for i in $(UDEV_RULES); do \

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -34,9 +34,20 @@ rm -rf $RPM_BUILD_ROOT
 cp -f /etc/lvm/lvm.conf /etc/lvm/master/lvm.conf || exit $?
 sed -i 's/metadata_read_only =.*/metadata_read_only = 1/' /etc/lvm/lvm.conf || exit $?
 sed -i 's/metadata_read_only =.*/metadata_read_only = 0/' /etc/lvm/master/lvm.conf || exit $?
+# We try to be "update-alternatives" ready.
+# If a file exists and it is not a symlink we back it up
+if [ -e /etc/multipath.conf -a ! -h /etc/multipath.conf ]; then
+   mv -f /etc/multipath.conf /etc/multipath.conf.$(date +%F_%T)
+fi
+update-alternatives --install /etc/multipath.conf multipath.conf /etc/multipath.xenserver/multipath.conf 90
 
 %preun
 [ ! -x /sbin/chkconfig ] || chkconfig --del sm-multipath
+#only remove in case of erase (but not at upgrade)
+if [ $1 -eq 0 ] ; then
+	update-alternatives --remove multipath.conf /etc/multipath.xenserver/multipath.conf
+fi
+exit 0
 
 %postun
 [ ! -d /etc/lvm/master ] || rm -Rf /etc/lvm/master || exit $?
@@ -244,6 +255,7 @@ cp -f /etc/lvm/lvm.conf.orig /etc/lvm/lvm.conf || exit $?
 /sbin/mpathutil
 /etc/rc.d/init.d/sm-multipath
 %config /etc/udev/rules.d/40-multipath.rules
+%config /etc/multipath.xenserver/multipath.conf
 
 
 %changelog

--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -1,0 +1,37 @@
+# For a configuration sample refer to multipath documentation.
+# To check current configuration values `multipathd -k"show conf"`
+defaults {
+	user_friendly_names	no
+}
+devices {
+	device {
+		vendor			"DELL",
+		product			"MD36xx(i|f)",
+		features		"2 pg_init_retries 50",
+		hardware_handler	"1 rdac",
+		path_selector		"round-robin 0",
+		path_grouping_policy	group_by_prio,
+		failback		immediate,
+		rr_min_io		100,
+		path_checker		rdac,
+		prio			rdac,
+		no_path_retry		30
+	}
+	device {
+		vendor			"IBM",
+		product			"1723*",
+		hardware_handler	"1 rdac",
+		path_selector		"round-robin 0",
+		path_grouping_policy	group_by_prio,
+		failback		immediate,
+		path_checker		rdac,
+		prio			rdac,
+	}
+	device {
+		vendor			"DataCore",
+		product			"SAN*",
+		path_checker		"tur",
+		path_grouping_policy	failover,
+		failback		30,
+	}
+}


### PR DESCRIPTION
Migration of dm-multipath-conf.patch content from dm-multipath to sm
with basic conf file.
Previously we patched device-mapper-multipath to use a different
configuration file.

Those changes are now integrated into our own configuration file
that is installed using "alternatives" with a backup copy
if the original file is a regular file.

Signed-off-by: Germano Percossi germano.percossi@citrix.com
