### PR TITLE
CA-120469: Fail gracefull in case if rmdir errors out with ENOTEMPTY

### DIFF
--- a/drivers/refcounter.py
+++ b/drivers/refcounter.py
@@ -185,10 +185,13 @@ class RefCounter:
             os.unlink(objFile)
         except OSError:
             raise RefCounterException("failed to remove '%s'" % objFile)
-        if not os.listdir(nsDir):
-            try:
-                os.rmdir(nsDir)
-            except OSError:
+        
+        try:
+            os.rmdir(nsDir)
+        except OSError, e:
+            # Having a listdir wont help since there could be other vdi related
+            # operations that could create a file in between the python calls.
+            if e.errno != errno.ENOTEMPTY:
                 raise RefCounterException("failed to remove '%s'" % nsDir)
     _removeObject = staticmethod(_removeObject)
 


### PR DESCRIPTION
Parallel vm-suspend operations on vm that has got vdi's in the same SR
could result in reference files, ignoring rmdir error (ENOTEMPTY)
instead of lsdir looks a better option.

Signed-off-by: Vineeth Thampi Raveendran vineeth.thampi@citrix.com
