### PR TITLE
CA-122445: get_current_initiator_name fails to parse initiatorname.iscsi file on Debian

### DIFF
--- a/drivers/iscsilib.py
+++ b/drivers/iscsilib.py
@@ -246,9 +246,11 @@ def get_current_initiator_name():
         try:
             f=open(INITIATORNAME_FILE, 'r')
             for line in f.readlines():
-                if line.find("InitiatorName") != -1:
+                if line.strip().startswith("#"):
+                    continue 
+                if "InitiatorName" in line:
                     IQN = line.split("=")[1]
-                    currentIQN = IQN[:-1]
+                    currentIQN = IQN.strip()
                     f.close()
                     return currentIQN
             f.close()


### PR DESCRIPTION
On Debian, the /etc/iscsi/initiatorname.iscsi file has comments telling you
what to do with the InitiatorName parameter;  the previous code would try
to interpret this comment as the InitiatorName setting and fail to parse it.

Signed-off-by: Euan Harris euan.harris@citrix.com
