### PR TITLE
CA-115035: mpath-boot and multipathed host other-config keys missing

### DIFF
--- a/drivers/mpathcount.py
+++ b/drivers/mpathcount.py
@@ -223,6 +223,9 @@ try:
             session.xenapi.host.add_to_other_config(localhost,key,val)
         config = session.xenapi.host.get_other_config(localhost)
         maps = mpath_cli.list_maps()
+        # Ensure output headers are not in the list
+        if 'name' in maps:
+            maps.remove('name')
         # first map will always correspond to the root dev, dm-0
         assert(len(maps) > 0)
         i = maps[0]


### PR DESCRIPTION
Before upgrading to the new kernel, the output of
multipath -k"show maps"
and
echo "show maps" |multipathd -k
were different.

Now they are the same but previous code in mpathcount.py was
relying exclusively on the wrong output in the previous version.

Now it is fixed in both cases

Signed-off-by: Germano Percossi germano.percossi@citrix.com
