### PR TITLE
CA-122950: Ignore invalid VDI handle exceptions in SR.scan

### DIFF
--- a/drivers/SR.py
+++ b/drivers/SR.py
@@ -558,8 +558,9 @@ class ScanRecord:
             try:
                 self.sr.forget_vdi(vdi['uuid'])
             except XenAPI.Failure, e:
-                if e.details == "HANDLE_INVALID" or e.details == "UUID_INVALID":
-                   util.SMlog("VDI %s not found, ignoring exception" % vdi['uuid'])
+                if util.isInvalidVDI(e):
+                   util.SMlog("VDI %s not found, ignoring exception" \
+                           % vdi['uuid'])
                 else:
                    raise
 

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -258,11 +258,6 @@ class XAPI:
         if self.sessionPrivate:
             self.session.xenapi.session.logout()
 
-    def isInvalidVDI(exception):
-        return exception.details[0] == "HANDLE_INVALID" or \
-                exception.details[0] == "UUID_INVALID"
-    isInvalidVDI = staticmethod(isInvalidVDI)
-
     def isPluggedHere(self):
         pbds = self.getAttachedPBDs()
         for pbdRec in pbds:
@@ -512,7 +507,7 @@ class VDI:
                         self.sr.uuid, self.uuid):
                     raise util.SMException("Failed to refresh %s" % self)
             except XenAPI.Failure, e:
-                if self.sr.xapi.isInvalidVDI(e) and ignoreNonexistent:
+                if util.isInvalidVDI(e) and ignoreNonexistent:
                     Util.log("VDI %s not found, ignoring" % self)
                     return
                 raise
@@ -1728,7 +1723,7 @@ class SR:
             ret = self.xapi.singleSnapshotVDI(vdi)
             Util.log("Single-snapshot returned: %s" % ret)
         except XenAPI.Failure, e:
-            if self.xapi.isInvalidVDI(e):
+            if util.isInvalidVDI(e):
                 Util.log("The VDI appears to have been concurrently deleted")
                 return False
             raise

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1647,3 +1647,7 @@ def open_atomic(path, mode=None):
     except:
         os.close(fd)
         raise
+
+def isInvalidVDI(exception):
+    return exception.details[0] == "HANDLE_INVALID" or \
+            exception.details[0] == "UUID_INVALID"


### PR DESCRIPTION
Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
