### PR TITLE
revert 666f0b56df0dd2bb5361659f7bc4c4329c4c4aca

### DIFF
--- a/drivers/journaler.py
+++ b/drivers/journaler.py
@@ -64,34 +64,16 @@ class Journaler:
             fullPath = self.lvmCache._getPath(lvName)
             fd =  open_file(fullPath, True)
             try:
-                e = None
                 try:
                     min_block_size = get_min_blk_size_wrapper(fd)
                     data = "%d %s" % (len(val), val)
-                    xs_file_write_wrapper(fd, 0, min_block_size, data,
-                            len(data))
-                except Exception, e:
-                    raise
+                    xs_file_write_wrapper(fd, 0, min_block_size, data, len(data))
                 finally:
-                    try:
-                        close(fd)
-                        self.lvmCache.deactivateNoRefcount(lvName)
-                    except Exception, e2:
-                        msg = 'failed to close/deactivate %s: %s' \
-                                % (lvName, e2)
-                        if not e:
-                            util.SMlog(msg)
-                            raise e2
-                        else:
-                            util.SMlog('WARNING: %s (error ignored)' % msg)
-
+                    close(fd)
+                    self.lvmCache.deactivateNoRefcount(lvName)
             except:
                 util.logException("journaler.create")
-                try:
-                    self.lvmCache.remove(lvName)
-                except Exception, e:
-                    util.SMlog('WARNING: failed to clean up failed journal ' \
-                            ' creation: %s (error ignored)' % e)
+                self.lvmCache.remove(lvName)
                 raise JournalerException("Failed to write to journal %s" \
                     % lvName)
 

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -67,7 +67,7 @@ class CommandException(SMException):
         self.code = code
         self.cmd = cmd
         self.reason = reason
-        Exception.__init__(self, os.strerror(abs(code)))
+        Exception.__init__(self, code)
 
 class SRBusyException(SMException):
     """The SR could not be locked"""


### PR DESCRIPTION
This commit reverts "CA-122253: Improve error reporting for LVM-based SR
snapshots" as it hasn't been tested by a storage BST and the imminent
backout merge from trunk-storage into trunk could introduce regressions.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
