### PR TITLE
CP-7343: Enable conversion for whitespaces

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -2,6 +2,7 @@
 # To check current configuration values `multipathd -k"show conf"`
 defaults {
 	user_friendly_names	no
+	replace_wwid_whitespace	yes
 }
 blacklist {
 	wwid "*"


### PR DESCRIPTION
Enable CentOS 6.5 flag to fix problem with devices with padded IDs.
Use same name mangling as udev rules.

Signed-off-by: Frediano Ziglio frediano.ziglio@citrix.com
