### PR TITLE
CA-125230: Fix compilation for 64 bit

### DIFF
--- a/mk/Makefile
+++ b/mk/Makefile
@@ -79,4 +79,4 @@ $(MY_OUTPUT_DIR)/$(ERRORCODES_XML):
 	cp $(REPO)/drivers/$(ERRORCODES_XML) $@
 
 $(SUPPORT_PACK): $(SM_STAMP)
-	python setup.py --out $(dir $@) --pdn $(PRODUCT_BRAND) --pdv $(PRODUCT_VERSION) --bld $(BUILD) --spn "borehamwood-supp-pack" --spd "XenServer RawHBA implementation" --rxv "6.1.0" $(RPM_RPMSDIR)/$(DOMAIN0_ARCH_OPTIMIZED)/sm-rawhba-*.i686.rpm
+	python setup.py --out $(dir $@) --pdn $(PRODUCT_BRAND) --pdv $(PRODUCT_VERSION) --bld $(BUILD) --spn "borehamwood-supp-pack" --spd "XenServer RawHBA implementation" --rxv "6.1.0" $(RPM_RPMSDIR)/$(DOMAIN0_ARCH_OPTIMIZED)/sm-rawhba-*.$(DOMAIN0_ARCH_OPTIMIZED).rpm


### PR DESCRIPTION
Support pack use fixed build architecture.
Change to detect architecture to fix building on 64 bit architecture and
stay compatible with 32 bit one.

Signed-off-by: Frediano Ziglio frediano.ziglio@citrix.com
