### PR TITLE
CA-125486: Don't use commas in /etc/multipath.conf

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -11,34 +11,34 @@ blacklist_exceptions {
 }
 devices {
 	device {
-		vendor			"DELL",
-		product			"MD36xx(i|f)",
-		features		"2 pg_init_retries 50",
-		hardware_handler	"1 rdac",
-		path_selector		"round-robin 0",
-		path_grouping_policy	group_by_prio,
-		failback		immediate,
-		rr_min_io		100,
-		path_checker		rdac,
-		prio			rdac,
+		vendor			"DELL"
+		product			"MD36xx(i|f)"
+		features		"2 pg_init_retries 50"
+		hardware_handler	"1 rdac"
+		path_selector		"round-robin 0"
+		path_grouping_policy	group_by_prio
+		failback		immediate
+		rr_min_io		100
+		path_checker		rdac
+		prio			rdac
 		no_path_retry		30
 	}
 	device {
-		vendor			"IBM",
-		product			"1723*",
-		hardware_handler	"1 rdac",
-		path_selector		"round-robin 0",
-		path_grouping_policy	group_by_prio,
-		failback		immediate,
-		path_checker		rdac,
-		prio			rdac,
+		vendor			"IBM"
+		product			"1723*"
+		hardware_handler	"1 rdac"
+		path_selector		"round-robin 0"
+		path_grouping_policy	group_by_prio
+		failback		immediate
+		path_checker		rdac
+		prio			rdac
 	}
 	device {
-		vendor			"DataCore",
-		product			"SAN*",
-		path_checker		"tur",
-		path_grouping_policy	failover,
-		failback		30,
+		vendor			"DataCore"
+		product			"SAN*"
+		path_checker		"tur"
+		path_grouping_policy	failover
+		failback		30
 	}
 	device {
 		vendor "NETAPP"


### PR DESCRIPTION
The syntax of some of the custom entries in /etc/multipath.conf is wrong. It is
not valid to separate parameter declarations using commas.

The DM multipath parser misreads and does not apply the erroneous custom
configuration entries.

Signed-off-by: Robert Breker robert.breker@citrix.com
