### PR TITLE
CP-7199: Enable detect_prio setting again

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -41,9 +41,4 @@ devices {
 		path_grouping_policy	failover,
 		failback		30,
 	}
-	device {
-		vendor "NETAPP"
-		product "LUN.*"
-		detect_prio no
-	}
 }


### PR DESCRIPTION
Now with package from CentOS 6.5 ALUA works correctly with this setting.

Signed-off-by: Frediano Ziglio frediano.ziglio@citrix.com
