### PR TITLE
CA-127209: Disk may not have enough space to do a parent inflate

### DIFF
--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -894,11 +894,6 @@ class LVHDSR(SR.SR):
         elif base.vdiType == vhdutil.VDI_TYPE_RAW and base.hidden:
             self.lvmCache.setHidden(base.name, False)
 
-        # inflate the parent to fully-allocated size
-        if base.vdiType == vhdutil.VDI_TYPE_VHD:
-            fullSize = lvhdutil.calcSizeVHDLV(vhdInfo.sizeVirt)
-            lvhdutil.inflate(self.journaler, self.uuid, baseUuid, fullSize)
-
         # remove the child nodes
         if clonUuid and lvs.get(clonUuid):
             if lvs[clonUuid].vdiType != vhdutil.VDI_TYPE_VHD:
@@ -908,6 +903,11 @@ class LVHDSR(SR.SR):
                 self.lvActivator.remove(clonUuid, False)
         if lvs.get(origUuid):
             self.lvmCache.remove(lvs[origUuid].name)
+
+        # inflate the parent to fully-allocated size
+        if base.vdiType == vhdutil.VDI_TYPE_VHD:
+            fullSize = lvhdutil.calcSizeVHDLV(vhdInfo.sizeVirt)
+            lvhdutil.inflate(self.journaler, self.uuid, baseUuid, fullSize)
 
         # rename back
         origLV = lvhdutil.LV_PREFIX[base.vdiType] + origUuid


### PR DESCRIPTION
In case when the clone operation failed for Out of Storage, disk may not
have enough space to do a inflate parent keeping the full sized child.
The order of operation should be to delete the children, and then go for
a parent inflate
