### PR TITLE
CA-127463: After a snapshot failure, VHDs are left in PAUSED state

### DIFF
--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -917,6 +917,11 @@ class LVHDSR(SR.SR):
             self.lvActivator.replace(baseUuid, origUuid, origLV, False)
         RefCounter.set(origUuid, origRefcountNormal, origRefcountBinary, ns)
 
+        # At this stage, tapdisk and SM vdi will be in paused state. Remove
+        # flag to facilitate vm deactivate
+        origVdiRef = self.session.xenapi.VDI.get_by_uuid(origUuid)
+        self.session.xenapi.VDI.remove_from_sm_config(origVdiRef, 'paused')
+
         # update LVM metadata on slaves 
         slaves = util.get_slaves_attached_on(self.session, [origUuid])
         lvhdutil.lvRefreshOnSlaves(self.session, self.uuid, self.vgname,


### PR DESCRIPTION
In the event of a snapshot failure, both tapdisk and VHDs are left in
paused state. During the recovery cycle using journaler mechanism, the
VHDs are brought back to a stable state, but further vdi deactivate will
fail with VHDs in paused state. Currently there is no mechanism to
unpause the VHDs and the tapdisk.
