### PR TITLE
Revert "CA-117628: allow LVM metadata updates when running through plug-...

### DIFF
--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -1982,12 +1982,10 @@ class LVHDVDI(VDI.VDI):
                 fn = "detach"
             pools = self.session.xenapi.pool.get_all()
             master = self.session.xenapi.pool.get_master(pools[0])
-            rv = eval(self.session.xenapi.host.call_plugin(
-                    master, self.sr.THIN_PLUGIN, fn,
-                    {"srUuid": self.sr.uuid, "vdiUuid": self.uuid}))
-            util.SMlog("call-plugin returned: '%s'" % rv)
-            if not rv:
-                raise Exception('failed to run plugin on master: %s' % rv)
+            text = self.session.xenapi.host.call_plugin( \
+                    master, self.sr.THIN_PLUGIN, fn, \
+                    {"srUuid": self.sr.uuid, "vdiUuid": self.uuid})
+            util.SMlog("call-plugin returned: '%s'" % text)
             # refresh to pick up the size change on this slave
             self.sr.lvmCache.activateNoRefcount(self.lvname, True)
 

--- a/drivers/lvhd-thin
+++ b/drivers/lvhd-thin
@@ -26,12 +26,8 @@ import vhdutil
 import lvhdutil
 from lvmcache import LVMCache
 from journaler import Journaler
-import lvutil
-import os
 
 def attach(session, args):
-    if util.is_master(session):
-        os.environ['LVM_SYSTEM_DIR'] = lvutil.MASTER_LVM_CONF
     srUuid = args["srUuid"]
     vdiUuid = args["vdiUuid"]
     vgName = "%s%s" % (lvhdutil.VG_PREFIX, srUuid)
@@ -45,8 +41,6 @@ def attach(session, args):
     return str(False)
 
 def detach(session, args):
-    if util.is_master(session):
-        os.environ['LVM_SYSTEM_DIR'] = lvutil.MASTER_LVM_CONF
     srUuid = args["srUuid"]
     vdiUuid = args["vdiUuid"]
     vgName = "%s%s" % (lvhdutil.VG_PREFIX, srUuid)

--- a/drivers/lvhdutil.py
+++ b/drivers/lvhdutil.py
@@ -178,9 +178,8 @@ def inflate(journaler, srUuid, vdiUuid, size):
     util.fistpoint.activate("LVHDRT_inflate_after_create_journal",srUuid)
     lvmCache.setSize(lvName, newSize)
     util.fistpoint.activate("LVHDRT_inflate_after_setSize",srUuid)
-    if not util.zeroOut(path, newSize - vhdutil.VHD_FOOTER_SIZE,
-            vhdutil.VHD_FOOTER_SIZE):
-        raise Exception('failed to zero out VHD footer')
+    util.zeroOut(path, newSize - vhdutil.VHD_FOOTER_SIZE,
+            vhdutil.VHD_FOOTER_SIZE)
     util.fistpoint.activate("LVHDRT_inflate_after_zeroOut",srUuid)
     vhdutil.setSizePhys(path, newSize, False)
     util.fistpoint.activate("LVHDRT_inflate_after_setSizePhys",srUuid)

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -578,11 +578,6 @@ def get_this_host():
     f.close()
     return uuid
 
-def is_master(session):
-    pools = session.xenapi.pool.get_all()
-    master = session.xenapi.pool.get_master(pools[0])
-    return get_this_host_ref(session) == master
-
 # XXX: this function doesn't do what it claims to do
 def get_localhost_uuid(session):
     filename = '/etc/xensource-inventory'


### PR DESCRIPTION
...in"

This reverts commit e4a239c3dcc901d63ffb71644e532c8d050b84aa. The commit
is reverted because it has apparently exposed an existing bug. Will
reapply the commit once this is confirmed and the bug fixed.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
