### PR TITLE
CA-128175: vhd-util check on ~TB sized disk taking long.

### DIFF
--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -670,11 +670,11 @@ class VDI:
         after reloading the entire SR in case things have changed while we
         were coalescing"""
         self.validate()
-        self.parent.validate()
+        self.parent.validate(True)
         self.parent._increaseSizeVirt(self.sizeVirt)
         self.sr._updateSlavesOnResize(self.parent)
         self._coalesceVHD(0)
-        self.parent.validate()
+        self.parent.validate(True)
         #self._verifyContents(0)
         self.parent.updateBlockInfo()
 


### PR DESCRIPTION
vhd-util check by default does a quadratic check on the BAT that takes a long time
(In the order of 10 mins) to finish. This inadvertently could block leaf
coalesce.
