### PR TITLE
CA-120162: don't fail if the GC can't be kicked

### DIFF
--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -1161,8 +1161,15 @@ class LVHDSR(SR.SR):
         if not lockRunning.acquireNoblock():
             if cleanup.should_preempt(self.session, self.uuid):
                 util.SMlog("Aborting currently-running coalesce of garbage VDI")
-                if not cleanup.abort(self.uuid, soft=True):
-                    util.SMlog("The GC has already been scheduled to re-start") 
+                try:
+                    if not cleanup.abort(self.uuid, soft=True):
+                        util.SMlog("The GC has already been scheduled to "
+                                "re-start")
+                except util.CommandException, e:
+                    if e.code != errno.ETIMEDOUT:
+                        raise
+                    util.SMlog('failed to abort the GC')
+                finally:
                     return
             else:
                 util.SMlog("A GC instance already running, not kicking")

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -2577,8 +2577,8 @@ def _abort(srUuid, soft=False):
             time.sleep(SR.LOCK_RETRY_INTERVAL)
         abortFlag.clear(FLAG_TYPE_ABORT)
         if not gotLock:
-            raise util.SMException("SR %s: error aborting existing process" % \
-                    srUuid)
+            raise util.CommandException(code=errno.ETIMEDOUT,
+                    reason="SR %s: error aborting existing process" % srUuid)
     return True
 
 def init(srUuid):


### PR DESCRIPTION
When a VDI.delete needs to abort the GC and restart it, a deadlock might
occur which leads to reporting that VDI.delete while it has partially
succeeded, as the actual deletion of the VDI will happen sooner or
later. Fixing the deadlock is not straightforward, so the best effort
solution is to simply ignore such failures.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
