### PR TITLE
CA-128373: move lvm.conf patch from dom0.hg to sm

### DIFF
--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -33,9 +33,12 @@ service sm-multipath start
 
 [ -f /etc/lvm/lvm.conf.orig ] || cp /etc/lvm/lvm.conf /etc/lvm/lvm.conf.orig || exit $?
 [ -d /etc/lvm/master ] || mkdir /etc/lvm/master || exit $?
-cp -f /etc/lvm/lvm.conf /etc/lvm/master/lvm.conf || exit $?
-sed -i 's/metadata_read_only =.*/metadata_read_only = 1/' /etc/lvm/lvm.conf || exit $?
+mv -f /etc/lvm/lvm.conf /etc/lvm/master/lvm.conf || exit $?
 sed -i 's/metadata_read_only =.*/metadata_read_only = 0/' /etc/lvm/master/lvm.conf || exit $?
+sed -i 's/archive = .*/archive = 0/' /etc/lvm/master/lvm.conf || exit $?
+sed -i 's/filter \= \[ \"a\/\.\*\/\" \]/filter = \[ \"r\|\/dev\/xvd\.\|\"\, \"r\|\/dev\/VG\_Xen\.\*\/\*\|\"\]/g' /etc/lvm/master/lvm.conf || exit $?
+cp /etc/lvm/master/lvm.conf /etc/lvm/lvm.conf || exit $?
+sed -i 's/metadata_read_only =.*/metadata_read_only = 1/' /etc/lvm/lvm.conf || exit $?
 # We try to be "update-alternatives" ready.
 # If a file exists and it is not a symlink we back it up
 if [ -e /etc/multipath.conf -a ! -h /etc/multipath.conf ]; then


### PR DESCRIPTION
Patch in dom0.hg/patches.dom0/patch-etc_lvm_lvm.conf takes care of
CA-16427 and CA-57153. Because of CP-5830, we end up with inconsistent
lvm.conf files. We drop the patch from dom0.hg and now configure
lvm.conf during SM RPM installation time, the same way we do for CP-5830.

NB the way we configure lvm.conf is very fragile, we should use
Germano's Python script for Borehamwood (it lives in
tampa-lcm/sm.hg/mk/sm.spec.in).

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
