### PR TITLE
CA-129187: remove xs path to ignore error if path does not exist

### DIFF
--- a/snapwatchd/snapwatchd
+++ b/snapwatchd/snapwatchd
@@ -791,7 +791,8 @@ class create_snapshot(SnapParentThread):
                 if len(remainingSnaps) > 0:
                     DEBUG("Unable to service full snap request list: %s" % uuidlist)
                     raise Exception
-        except:
+        except Exception, e:
+            DEBUG("VSS snapshots failed for VM %s. err: %s" % (self.vm_uuid, e))
             CleanupSnapParentThread(self)
             xslib.setval(self.xsh, "%s/status"%self.base, "snapshots-failed")
             del self.xsh

--- a/snapwatchd/xslib.py
+++ b/snapwatchd/xslib.py
@@ -50,9 +50,7 @@ def remove_xs_entry(h, dom_uuid, dom_path):
         try:
             h.rm('', path)
         except:
-            raise "Unable to remove xenstore-node"
-    else:
-        raise "Invalid dom and path specified"
+            raise Exception("Unable to remove xenstore-node")
 
 def set_watch(h, path):
     return h.watch(path, '')


### PR DESCRIPTION
Also modified the way exception is raised, use Exception class
instead of string

Signed-off-by: Vineeth Thampi Raveendran vineeth.thampi@citrix.com
