### PR TITLE
CA-122205: More race conditions.

### DIFF
--- a/drivers/journaler.py
+++ b/drivers/journaler.py
@@ -169,8 +169,9 @@ class Journaler:
                 else:
                     raise
             except util.CommandException, e:
-                if e.code in [errno.ENOENT, errno.EIO]:
-                    util.SMlog("Ignoring EIO/ENOENT errors for journal %s" % lvName)
+                if e.code in [errno.ENOENT, errno.EIO, -1]:
+                    util.SMlog("Ignoring EIO/ENOENT/LV not activate errors for"
+                               "journal %s" % lvName)
                     continue
                 else:
                     raise


### PR DESCRIPTION
dmsetup table LV called from _checkActive could error out
if GC running in parallel has removed the LV.

Signed-off-by: Vineeth Thampi Raveendran vineeth.thampi@citrix.com
