### PR TITLE
revert CA-114341 patches

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1285,16 +1285,7 @@ class VDI(object):
             util.SMlog("tap.deactivate: Shut down %s" % tapdisk)
 
     @classmethod
-    def tap_pause(cls, session, sr_uuid, vdi_uuid, failfast=False):
-        """
-        Pauses the tapdisk.
-
-        session: a XAPI session
-        sr_uuid: the UUID of the SR on which VDI lives
-        vdi_uuid: the UUID of the VDI to pause
-        failfast: controls whether the VDI lock should be acquired in a
-            non-blocking manner
-        """
+    def tap_pause(cls, session, sr_uuid, vdi_uuid):
         util.SMlog("Pause request for %s" % vdi_uuid)
         vdi_ref = session.xenapi.VDI.get_by_uuid(vdi_uuid)
         session.xenapi.VDI.add_to_sm_config(vdi_ref, 'paused', 'true')
@@ -1303,7 +1294,7 @@ class VDI(object):
             host_ref = key[len('host_'):]
             util.SMlog("Calling tap-pause on host %s" % host_ref)
             if not cls.call_pluginhandler(session, host_ref,
-                    sr_uuid, vdi_uuid, "pause", failfast=failfast):
+                    sr_uuid, vdi_uuid, "pause"):
                 # Failed to pause node
                 session.xenapi.VDI.remove_from_sm_config(vdi_ref, 'paused')
                 return False
@@ -1341,11 +1332,10 @@ class VDI(object):
 
     @classmethod
     def call_pluginhandler(cls, session, host_ref, sr_uuid, vdi_uuid, action,
-            secondary = None, activate_parents = False, failfast=False):
+            secondary = None, activate_parents = False):
         """Optionally, activate the parent LV before unpausing"""
         try:
-            args = {"sr_uuid":sr_uuid, "vdi_uuid":vdi_uuid,
-                    "failfast": str(failfast)}
+            args = {"sr_uuid":sr_uuid,"vdi_uuid":vdi_uuid}
             if secondary:
                 args["secondary"] = secondary
             if activate_parents:

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -491,9 +491,9 @@ class VDI:
             Util.log("Unpausing VDI %s" % self)
             self.unpause()
 
-    def pause(self, failfast=False):
+    def pause(self):
         if not blktap2.VDI.tap_pause(self.sr.xapi.session, self.sr.uuid,
-                self.uuid, failfast):
+                self.uuid):
             raise util.SMException("Failed to pause VDI %s" % self)
 
     def unpause(self):
@@ -1768,7 +1768,7 @@ class SR:
                 return False
 
             uuid = vdi.uuid
-            vdi.pause(failfast=True)
+            vdi.pause()
             try:
                 try:
                     # "vdi" object will no longer be valid after this call

--- a/drivers/tapdisk-pause
+++ b/drivers/tapdisk-pause
@@ -35,12 +35,7 @@ TAPDEV_PHYPATH_PFX = "/dev/sm/phy"
 def locking(excType, override=True):
     def locking2(op):
         def wrapper(self, *args):
-            if self.failfast:
-                if not self.lock.acquireNoblock():
-                    raise xs_errors.XenError(excType,
-                            opterr='VDI already locked')
-            else:
-                self.lock.acquire()
+            self.lock.acquire()
             try:
                 try:
                     ret = op(self, *args)
@@ -110,11 +105,6 @@ class Tapdisk:
     def __init__(self, session, args):
         self.sr_uuid = args["sr_uuid"]
         self.vdi_uuid = args["vdi_uuid"]
-        # Tells whether the lock must be acquired in a non-blocking manner.
-        if 'failfast' in args:
-            self.failfast = eval(args['failfast'])
-        else:
-            self.failfast = False
         self.session = session
         self.path = os.path.join(TAPDEV_BACKPATH_PFX,self.sr_uuid,self.vdi_uuid)
         self.phypath = os.path.join(TAPDEV_PHYPATH_PFX,self.sr_uuid,self.vdi_uuid)


### PR DESCRIPTION
The CA-114341 patches fail to pass the BST as some curious locking
issues appear. It's not yet clear whether these patches are just wrong
or whether they uncover an existing issue. I'm removing them for now to
unblock the BST and the merge into trunk.

This patch reverts the following commits:
- 8c1c069c: "CA-114341: don't try to reacquire the lock"
- 1f5db2b3: "CA-114341: explicitly use keyword argument"
- a47ceebb: "CA-114341: GC: acquire VDI lock non-blocking"

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
