### PR TITLE
Revert "CA-114341: check return value of LVHD plugins"

### DIFF
--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -1135,11 +1135,9 @@ class LVHDSR(SR.SR):
                 continue
             util.SMlog("Updating %s, %s, %s on slave %s" % \
                     (origOldLV, origLV, baseLV, hostRef))
-            rv = eval(self.session.xenapi.host.call_plugin(
-                    hostRef, self.PLUGIN_ON_SLAVE, "multi", args))
-            util.SMlog("call-plugin returned: %s" % rv)
-            if not rv:
-                raise Exception('plugin %s failed' % self.PLUGIN_ON_SLAVE)
+            text = self.session.xenapi.host.call_plugin( \
+                    hostRef, self.PLUGIN_ON_SLAVE, "multi", args)
+            util.SMlog("call-plugin returned: '%s'" % text)
 
     def _cleanup(self, skipLockCleanup = False):
         """delete stale refcounter, flag, and lock files"""
@@ -1996,12 +1994,10 @@ class LVHDVDI(VDI.VDI):
                 fn = "detach"
             pools = self.session.xenapi.pool.get_all()
             master = self.session.xenapi.pool.get_master(pools[0])
-            rv = eval(self.session.xenapi.host.call_plugin(
-                    master, self.sr.THIN_PLUGIN, fn,
-                    {"srUuid": self.sr.uuid, "vdiUuid": self.uuid}))
-            util.SMlog("call-plugin returned: %s" % rv)
-            if not rv:
-                raise Exception('plugin %s failed' % self.sr.THIN_PLUGIN)
+            text = self.session.xenapi.host.call_plugin( \
+                    master, self.sr.THIN_PLUGIN, fn, \
+                    {"srUuid": self.sr.uuid, "vdiUuid": self.uuid})
+            util.SMlog("call-plugin returned: '%s'" % text)
             # refresh to pick up the size change on this slave
             self.sr.lvmCache.activateNoRefcount(self.lvname, True)
 

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1344,8 +1344,8 @@ class VDI(object):
                     host_ref, PLUGIN_TAP_PAUSE, action,
                     args)
             return ret == "True"
-        except Exception, e:
-            util.logException("BLKTAP2:call_pluginhandler %s" % e)
+        except:
+            util.logException("BLKTAP2:call_pluginhandler")
             return False
 
 

--- a/drivers/lvhd-thin
+++ b/drivers/lvhd-thin
@@ -40,8 +40,8 @@ def attach(session, args):
     try:
         lvhdutil.attachThin(journaler, srUuid, vdiUuid)
         return str(True)
-    except Exception, e:
-        util.logException("lvhd-thin:attach" % e)
+    except:
+        util.logException("lvhd-thin:attach")
     return str(False)
 
 def detach(session, args):
@@ -54,8 +54,8 @@ def detach(session, args):
     try:
         lvhdutil.detachThin(session, lvmCache, args["srUuid"], args["vdiUuid"])
         return str(True)
-    except Exception, e:
-        util.logException("lvhd-thin:detach %s" % e)
+    except:
+        util.logException("lvhd-thin:detach")
     return str(False)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This reverts commit 4bdb01aa761d73519c2e14410a3e63f291918524. We revert
the commit because it uncovers an existing bug (fixing it is not
trivial) in order to unblock the merge.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
