### PR TITLE
CA-135612: Add experimental support for NFSv4 to SM

### DIFF
--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -93,10 +93,11 @@ def soft_mount(mountpoint, remoteserver, remotepath, transport, timeout=0,
     if timeout < 1:
         timeout = SOFTMOUNT_TIMEOUT
 
-    options = "soft,timeo=%d,retrans=%d,proto=%s" % (
-                                               timeout * 10,
-                                               SOFTMOUNT_RETRANS,
-                                               transport)
+    options = "soft,timeo=%d,retrans=%d,proto=%s,vers=%s" % (
+                                                             timeout * 10,
+                                                             SOFTMOUNT_RETRANS,
+                                                             transport,
+                                                             nfsversion)
     options += ',acdirmin=0,acdirmax=0'
 
     try:

--- a/tests/test_nfs.py
+++ b/tests/test_nfs.py
@@ -20,10 +20,11 @@ class Test_nfs(unittest.TestCase):
         pread.assert_called_once_with(['/usr/sbin/rpcinfo', '-t', 'aServer',
                                       'nfs', 'aNfsversion'])
 
-    def get_soft_mount_pread(self, binary):
+    def get_soft_mount_pread(self, binary, vers):
         return ([binary, 'remoteserver:remotepath', 'mountpoint', '-o',
-                 'soft,timeo=600,retrans=2147483647,proto=transport,acdirmin=0'
-                 ',acdirmax=0'])
+                 'soft,timeo=600,retrans=2147483647,proto=transport,'
+                 'vers=%s,acdirmin=0,acdirmax=0' % (vers)]
+                )
 
     @mock.patch('util.makedirs')
     @mock.patch('util.pread')
@@ -31,7 +32,8 @@ class Test_nfs(unittest.TestCase):
         nfs.soft_mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
                        timeout=0)
 
-        pread.assert_called_once_with(self.get_soft_mount_pread('mount.nfs'))
+        pread.assert_called_once_with(self.get_soft_mount_pread('mount.nfs',
+                                                                '3'))
 
     @mock.patch('util.makedirs')
     @mock.patch('util.pread')
@@ -39,7 +41,8 @@ class Test_nfs(unittest.TestCase):
         nfs.soft_mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
                        timeout=0, nfsversion='3')
 
-        pread.assert_called_once_with(self.get_soft_mount_pread('mount.nfs'))
+        pread.assert_called_once_with(self.get_soft_mount_pread('mount.nfs',
+                                                                '3'))
 
     @mock.patch('util.makedirs')
     @mock.patch('util.pread')
@@ -47,7 +50,8 @@ class Test_nfs(unittest.TestCase):
         nfs.soft_mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
                        timeout=0, nfsversion='4')
 
-        pread.assert_called_once_with(self.get_soft_mount_pread('mount.nfs4'))
+        pread.assert_called_once_with(self.get_soft_mount_pread('mount.nfs4',
+                                                                '4'))
 
     def test_validate_nfsversion_invalid(self):
         for thenfsversion in ['2', '4.1']:


### PR DESCRIPTION
This enables the specification of the NFS version (3,4) in the device-config of
ISOSRs(type=nfs) and NFSSRs.
E.g. device-config:nfsversion=4

Signed-off-by: Robert Breker <robert.breker@citrix.com>