### PR TITLE
CA-125717: Specify dev_loss_tmo in /etc/multipath.conf

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -3,6 +3,7 @@
 defaults {
 	user_friendly_names	no
 	replace_wwid_whitespace	yes
+	dev_loss_tmo 30
 }
 blacklist {
 	wwid "*"


### PR DESCRIPTION
Since implementing CA-108915 we need to specify dev_loss_tmo in
/etc/multipath.conf to properly handle timed out devices.
It seems that the setting accidently got lost in a merge, when porting the
configuration file from guest-packages.hg to dm-multipath.git. This commit
reinstates the dev_loss_tmo setting that we had before.

Signed-off-by: Robert Breker robert.breker@citrix.com
