### PR TITLE
CA-118899: Support UTF-8 iSCSI target names.

### DIFF
--- a/drivers/ISCSISR.py
+++ b/drivers/ISCSISR.py
@@ -183,7 +183,7 @@ class ISCSISR(SR.SR):
             self._scan_IQNs()
             raise xs_errors.XenError('ConfigTargetIQNMissing')
 
-        self.targetIQN = self.dconf['targetIQN']
+        self.targetIQN = unicode(self.dconf['targetIQN']).encode('utf-8')
         self.attached = False
         try:
             self.attached = iscsilib._checkTGT(self.targetIQN)


### PR DESCRIPTION
Signed-off-by: Rob Dobson rob@rdobson.co.uk
Acked-by: Thanos Makatos thanos.makatos@citrix.co.uk
Imported-by: Vineeth Raveendran vineeth.thampi@citrix.com

(cherry picked from commit 9dbd30cde957ad19ef5ba0e950d15712946975e8)
