### PR TITLE
CP-5962: after rawhba installation the SR is not enabled by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ install:
 	install -m 755 drivers/tapdisk-pause $(SM_STAGING)$(PLUGIN_SCRIPT_DEST)
 	install -m 755 drivers/vss_control $(SM_STAGING)$(PLUGIN_SCRIPT_DEST)
 	install -m 755 drivers/intellicache-clean $(SM_STAGING)$(PLUGIN_SCRIPT_DEST)
+	install -m 755 drivers/enable-borehamwood $(SM_STAGING)$(SM_DEST)
 	install -m 755 drivers/trim $(SM_STAGING)$(PLUGIN_SCRIPT_DEST)
 	ln -sf $(PLUGIN_SCRIPT_DEST)vss_control $(SM_STAGING)$(SM_DEST)
 	install -m 755 drivers/iscsilib.py $(SM_STAGING)$(SM_DEST)

--- a/drivers/enable-borehamwood
+++ b/drivers/enable-borehamwood
@@ -1,0 +1,54 @@
+#!/usr/bin/python
+# Copyright (C) 2014 Citrix Ltd.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation; version 2.1 only.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Lesser General Public License for more details.
+#
+
+import os, sys
+import subprocess
+
+DIR="/opt/xensource/sm/"
+FILENAME="RawHBASR"
+
+def usage():
+    print "Usage: %s enable" % (sys.argv[0])
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        usage()
+        sys.exit(1)
+
+    try:
+        os.chdir(DIR)
+        os.symlink(FILENAME + ".py", FILENAME)
+    except OSError, e:
+        print "Error: %s [errno=%s]" % (e.args)
+        sys.exit(1)
+
+    print "%s%s symlink created" % (DIR,FILENAME)
+
+    try:
+        ret = subprocess.call(["xe-toolstack-restart"])
+    except OSError, e:
+        print "Error: %s [errno=%s]" % (e.args)
+        ret = 1 # make the following block to cleanup
+
+    if ret != 0:
+        print "Failed toolstack restart, rolling back symlink creation"
+        try:
+            os.unlink(FILENAME)
+        except OSError, e:
+            print "Error: %s [errno=%s], fix manually" % (e.args)
+            sys.exit(1)
+    else:
+        print "toolstack restarted"
+
+    sys.exit(0)
+

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -252,10 +252,11 @@ This package adds a new rawhba SR type. This SR type allows utilization of
 Fiber Channel raw LUNs as separate VDIs (LUN per VDI)
 
 %files rawhba
-/opt/xensource/sm/RawHBASR
 /opt/xensource/sm/RawHBASR.py
+%exclude /opt/xensource/sm/RawHBASR
 /opt/xensource/sm/RawHBASR.pyc
 /opt/xensource/sm/RawHBASR.pyo
 /opt/xensource/sm/B_util.py
 /opt/xensource/sm/B_util.pyc
 /opt/xensource/sm/B_util.pyo
+/opt/xensource/sm/enable-borehamwood


### PR DESCRIPTION
Even though it is packaged in the main ISO and installed
by default, this patch will prevent the SR type to
be usable unless the proper script is run

Signed-off-by: Germano Percossi germano.percossi@citrix.com
