### PR TITLE
CA-142451: Fail to report all LUNs advertised on targets sharing the sam...

### DIFF
--- a/drivers/ISCSISR.py
+++ b/drivers/ISCSISR.py
@@ -228,15 +228,16 @@ class ISCSISR(SR.SR):
                     util.SMlog("PATHDICT: key %s: %s" % (key,rec))
                     addrlist.append(key)
 
-        # Try to detect an active path in order of priority
-        for key in self.pathdict:
-            if self.adapter.has_key(key):
-                self.tgtidx = key
-                self.path = self.pathdict[self.tgtidx]['path']
-                if os.path.exists(self.path):
-                    util.SMlog("Path found: %s" % self.path)
-                    break
-        self.address = self.tgtidx
+        if not os.path.exists(self.path):
+            # Try to detect an active path in order of priority
+            for key in self.pathdict:
+                if self.adapter.has_key(key):
+                    self.tgtidx = key
+                    self.path = self.pathdict[self.tgtidx]['path']
+                    if os.path.exists(self.path):
+                        util.SMlog("Path found: %s" % self.path)
+                        break
+            self.address = self.tgtidx
         self._synchroniseAddrList(addrlist)
 
     def _init_adapters(self):


### PR DESCRIPTION
...e IQN

If a multicontroller array advertises its targets using the same IQN
but different IPs and the LUNs in those targets are distinct,
we are able to show only LUNs coming from the first IP address.

The fix reinstates a line that was removed in commit 391bdf055dff
in our old sm.hg repository.

Signed-off-by: Germano Percossi germano.percossi@citrix.com
