### PR TITLE
xs64bit - Test support for experimenting with special SCSI devices

### DIFF
--- a/tests/test_devscan.py
+++ b/tests/test_devscan.py
@@ -45,7 +45,7 @@ class TestScan(unittest.TestCase, testlib.XmlMixIn):
     @testlib.with_context
     def test_scanning_sr_with_devices(self, context):
         sr = create_hba_sr()
-        adapter = context.adapter()
+        adapter = context.add_adapter(testlib.SCSIAdapter())
         adapter.add_disk()
         sr._init_hbadict()
 
@@ -66,7 +66,7 @@ class TestScan(unittest.TestCase, testlib.XmlMixIn):
     @testlib.with_context
     def test_scanning_sr_includes_parameters(self, context):
         sr = create_hba_sr()
-        adapter = context.adapter()
+        adapter = context.add_adapter(testlib.SCSIAdapter())
         adapter.add_disk()
         sr._init_hbadict()
         adapter.add_parameter('fc_host', dict(port_name='VALUE'))
@@ -98,7 +98,7 @@ class TestAdapters(unittest.TestCase):
 
     @testlib.with_context
     def test_adapter_and_disk_added(self, context):
-        adapter = context.adapter()
+        adapter = context.add_adapter(testlib.SCSIAdapter())
         adapter.add_disk()
 
         result = devscan.adapters()

--- a/tests/test_testlib.py
+++ b/tests/test_testlib.py
@@ -15,14 +15,14 @@ class TestTestContext(unittest.TestCase):
 
     @testlib.with_context
     def test_adapter_adds_scsi_host_entry(self, context):
-        context.adapter()
+        context.add_adapter(testlib.SCSIAdapter())
 
         self.assertEquals(['host0'], os.listdir('/sys/class/scsi_host'))
 
     @testlib.with_context
     def test_add_disk_adds_scsi_disk_entry(self, context):
         import glob
-        adapter = context.adapter()
+        adapter = context.add_adapter(testlib.SCSIAdapter())
         adapter.add_disk()
 
         self.assertEquals(
@@ -32,7 +32,7 @@ class TestTestContext(unittest.TestCase):
     @testlib.with_context
     def test_add_disk_adds_scsibus_entry(self, context):
         import glob
-        adapter = context.adapter()
+        adapter = context.add_adapter(testlib.SCSIAdapter())
         adapter.long_id = 'HELLO'
         adapter.add_disk()
 
@@ -42,7 +42,7 @@ class TestTestContext(unittest.TestCase):
 
     @testlib.with_context
     def test_add_disk_adds_device(self, context):
-        adapter = context.adapter()
+        adapter = context.add_adapter(testlib.SCSIAdapter())
         adapter.add_disk()
 
         self.assertEquals(
@@ -51,7 +51,7 @@ class TestTestContext(unittest.TestCase):
 
     @testlib.with_context
     def test_add_disk_adds_disk_by_id_entry(self, context):
-        adapter = context.adapter()
+        adapter = context.add_adapter(testlib.SCSIAdapter())
         disk = adapter.add_disk()
         disk.long_id = 'SOMEID'
 
@@ -60,21 +60,21 @@ class TestTestContext(unittest.TestCase):
     @testlib.with_context
     def test_add_disk_adds_glob(self, context):
         import glob
-        adapter = context.adapter()
+        adapter = context.add_adapter(testlib.SCSIAdapter())
         disk = adapter.add_disk()
 
         self.assertEquals(['/dev/disk/by-id'], glob.glob('/dev/disk/by-id'))
 
     @testlib.with_context
     def test_add_disk_path_exists(self, context):
-        adapter = context.adapter()
+        adapter = context.add_adapter(testlib.SCSIAdapter())
         disk = adapter.add_disk()
 
         self.assertTrue(os.path.exists('/dev/disk/by-id'))
 
     @testlib.with_context
     def test_add_parameter_parameter_file_exists(self, context):
-        adapter = context.adapter()
+        adapter = context.add_adapter(testlib.SCSIAdapter())
         disk = adapter.add_disk()
         adapter.add_parameter('fc_host', {'node_name': 'ignored'})
 
@@ -82,7 +82,7 @@ class TestTestContext(unittest.TestCase):
 
     @testlib.with_context
     def test_add_parameter_parameter_file_contents(self, context):
-        adapter = context.adapter()
+        adapter = context.add_adapter(testlib.SCSIAdapter())
         disk = adapter.add_disk()
         adapter.add_parameter('fc_host', {'node_name': 'value'})
 

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -305,11 +305,6 @@ class TestContext(object):
         self.scsi_adapters.append(adapter)
         return adapter
 
-    def adapter(self):
-        adapter = SCSIAdapter()
-        self.scsi_adapters.append(adapter)
-        return adapter
-
 
 def with_custom_context(context_class):
     def _with_context(func):


### PR DESCRIPTION
This change covers the `_extract_dev_name` function and also enables users to test scsi hosts with special devices. As an example, `AdapterWithNonBlockDevice` is exposing a special device.
