### PR TITLE
CA-141002: Enable ALUA auto-detection for DGC arrays

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -37,6 +37,12 @@ devices {
 		no_path_retry		30
 	}
 	device {
+		vendor			"DGC"
+		product			".*"
+		detect_prio		yes
+		retain_attached_hw_handler yes
+	}
+	device {
 		vendor			"EQLOGIC"
 		product			"100E-00"
 		path_grouping_policy	multibus


### PR DESCRIPTION
We have seen quite a few incidents where a configuration mismatch (ALUA vs.
DGC) between XS and the array caused confusion and got escalated: SCTX-1780,
SCTX-1333, CA-112771, CA-124429. This updated configuration will prevent such
misconfiguration incidents from reocurring, as XS will dynamically adapt to the
configuration on the array.

The partner has completed the qualification of the updated multipath
configuration with their storage arrays.

Signed-off-by: Robert Breker robert.breker@citrix.com
