### PR TITLE
CA-146822: fix intermittent test failures

### DIFF
--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -75,6 +75,9 @@ def create_lock_class_that_fails_to_create_file(number_of_failures):
 
 class TestLockDestruction(unittest.TestCase):
     def setUp(self):
+        gc.collect()
+        locks = self.retrieve_lock_instances_from_gc()
+        assert 0 == len(locks)
         gc.disable()
 
     @testlib.with_custom_context(FailingOpenContext)


### PR DESCRIPTION
As the lock test was querying the GC for the collected locks, it might
be possible that when the test starts, there is already an uncollected
lock in the GC. To avoid this situation, run the GC, so only the garbage
created by the test will be collected.

Signed-off-by: Mate Lakat mate.lakat@citrix.com
