### PR TITLE
Pin coverage's version

### DIFF
--- a/tests/setup_env_for_python_unittests.sh
+++ b/tests/setup_env_for_python_unittests.sh
@@ -20,6 +20,6 @@ else
     pip install nose
 fi
 
-pip install coverage
+pip install coverage==3.7.1
 pip install xenapi
 pip install mock


### PR DESCRIPTION
Coverage 4 appeared on pypi, which is not compatible with old python
interpreters. Pinning coverage to 3.7.1

Signed-off-by: Mate Lakat mate.lakat@citrix.com
