### PR TITLE
CA-148791: don't use absolute path for list_domains

### DIFF
--- a/snapwatchd/snapwatchd
+++ b/snapwatchd/snapwatchd
@@ -45,7 +45,7 @@ SNAP_GC_VDI_TASK_TAG = "VDI"
 SNAP_GC_FIELD_SEPARATOR = ":"
 SNAP_GC_TIME_INTERVAL = 60
 TASK_NAME_PREFIX = "OpaqueRef:"
-LIST_DOMAINS_BIN = "/opt/xensource/bin/list_domains"
+LIST_DOMAINS_BIN = "list_domains"
 
 def help():
     print "snapwatchd version %s:\n" % VERSION


### PR DESCRIPTION
list_domains used to live in /opt/xensource/bin in Creedence and in
/usr/bin in trunk, and since there's no good reason for using absolute
paths, so let's drop absolute paths.

Signed-off-by: Thanos Makatos thanos.makatos@citrix.com
