### PR TITLE
CA-153517: Fix LVHD SR delete

### DIFF
--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -562,11 +562,8 @@ class LVHDSR(SR.SR):
                                           replace('//', '-'))
                 lpath = os.path.join(self.path, lvname)
                 os.unlink(lpath)
-            except Exception, e:
-                if e.errno == errno.ENOENT:
-                    util.SMlog("Ignore ENOENT errors as dmsetup has removed " \
-                                "the symlink for file %s, path: %s." % (fileName, lpath))
-                else:
+            except OSError, e:
+                if e.errno != errno.ENOENT:
                     util.SMlog("LVHDSR.delete: failed to remove the symlink for " \
                                "file %s. Error: %s" % (fileName, str(e)))
                     success = False

--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -560,11 +560,16 @@ class LVHDSR(SR.SR):
             try:
                 lvname = os.path.basename(fileName.replace('-','/').\
                                           replace('//', '-'))
-                os.unlink(os.path.join(self.path, lvname))
+                lpath = os.path.join(self.path, lvname)
+                os.unlink(lpath)
             except Exception, e:
-                util.SMlog("LVHDSR.delete: failed to remove the symlink for " \
-                           "file %s. Error: %s" % (fileName, str(e)))
-                success = False
+                if e.errno == errno.ENOENT:
+                    util.SMlog("Ignore ENOENT errors as dmsetup has removed " \
+                                "the symlink for file %s, path: %s." % (fileName, lpath))
+                else:
+                    util.SMlog("LVHDSR.delete: failed to remove the symlink for " \
+                               "file %s. Error: %s" % (fileName, str(e)))
+                    success = False
 
         if success:
             try:


### PR DESCRIPTION
Due to differences in dmsetup version cleanups, this patch takes a safe
approach in the lvhdsr delete code-path.

Signed-off-by: Siddharth Vinothkumar <siddharth.vinothkumar@citrix.com>