### PR TITLE
Improving readcache check for file-based SRs

### DIFF
--- a/drivers/EXTSR.py
+++ b/drivers/EXTSR.py
@@ -74,8 +74,6 @@ class EXTSR(FileSR.FileSR):
         self.attached = self._checkmount()
         self.driver_config = DRIVER_CONFIG
 
-        self._check_o_direct()
-
     def delete(self, sr_uuid):
         super(EXTSR, self).delete(sr_uuid)
 

--- a/drivers/FileSR.py
+++ b/drivers/FileSR.py
@@ -86,6 +86,14 @@ class FileSR(SR.SR):
         else:
             self.o_direct = True
 
+
+    def __init__(self, srcmd, sr_uuid):
+        # We call SR.SR.__init__ explicitly because
+        # "super" sometimes failed due to circular imports
+        SR.SR.__init__(self, srcmd, sr_uuid)
+        self._check_o_direct()
+
+
     def load(self, sr_uuid):
         self.ops_exclusive = OPS_EXCLUSIVE
         self.lock = Lock(vhdutil.LOCK_TYPE_SR, self.uuid)
@@ -98,8 +106,6 @@ class FileSR(SR.SR):
         self.mountpoint = self.path
         self.attached = False
         self.driver_config = DRIVER_CONFIG
-
-        self._check_o_direct()
 
     def create(self, sr_uuid, size):
         """ Create the SR.  The path must not already exist, or if it does, 

--- a/drivers/NFSSR.py
+++ b/drivers/NFSSR.py
@@ -93,8 +93,6 @@ class NFSSR(FileSR.FileSR):
             self.transport = "udp"
         self.nfsversion = nfs.validate_nfsversion(self.dconf.get('nfsversion'))
 
-        self._check_o_direct()
-
 
     def validate_remotepath(self, scan):
         if not self.dconf.has_key('serverpath'):


### PR DESCRIPTION
The check introduced with commit 4be47e0 happens in the
load function.
This means that it has to be done for the load function
of every file based SR.

Putting the check in the FileSR constructor will make
it available for every derived class, without the need
to add the check for every new SR (as it happened to
me while playing with OCFSSR)

Signed-off-by: Germano Percossi <germano.percossi@citrix.com>