### PR TITLE
CAR-1442: Enable no-O_DIRECT read caching for VDIs on EXT and NFS SRs

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -395,6 +395,8 @@ class TapCtl(object):
         if options.get("timeout"):
             args.append("-t")
             args.append(str(options["timeout"]))
+        if not options.get("o_direct", True):
+            args.append("-D")
         cls._pread(args)
 
     @classmethod


### PR DESCRIPTION
Pass the "-D" argument to tap-ctl when opening an EXTFileVDI or an NFSFileVDI
to allow read caching by removing O_DIRECT.

Allow disabling read caching per-SR by setting other-config:o_direct to true.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>
Reviewed-by: Thanos Makatos <thanos.makatos@citrix.com>
Imported-by: Siddharth Vinothkumar <siddharth.vinothkumar@citrix.com>

(cherry picked from commit 4be47e0b137652ef4799931a87bca6ea4ef0dd67)

Fixed missing code chunks on master.

Conflicts:
	drivers/blktap2.py