### PR TITLE
CA-159585: Fix broken travis-CI for SM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: python
 python:
-    - "2.6"
+    - "2.7"
 # command to install dependencies
 install:
-      - "pip install -r requirements.txt --use-mirrors"
+      - "pip install -r requirements.txt"
 # command to run tests
 script:
+        - "python --version"
         - "pylint --version"
         - "PYTHONPATH=./snapwatchd:./drivers pylint --rcfile=tests/pylintrc ./drivers/*.py"
         - "cd drivers; nosetests --with-coverage -c ../.noserc ../tests/test_*.py"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mock
 xenapi
 coveralls
-pylint==1.2.0
+pylint==1.2


### PR DESCRIPTION
As part of out travis use, we do a pylint check on new pull requests.
Recently, as of pylint(v1.4) support for python 2.6 has been dropped.
Also, pylint uses `astroid` as an external dependency who's changes have
also broken support for python2.6.

Since we use python 2.7 on trunk, we should drop testing our patches on
python 2.6 and switch to 2.7.

Signed-off-by: Siddharth Vinothkumar <siddharth.vinothkumar@citrix.com>