### PR TITLE
CA-165487: Fix typo in SymLink.symlink

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1185,7 +1185,7 @@ class VDI(object):
             return os.readlink(self.path())
 
         def symlink(self):
-            return self.path
+            return self.path()
 
         def _mklink(self, target):
             os.symlink(target, self.path())


### PR DESCRIPTION
Fixes a missing set of brackets on os.path