### PR TITLE
CA-161436: Disable caching for CIFS ISO SRs

### DIFF
--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -257,7 +257,6 @@ class ISOSR(SR.SR):
                 mountcmd.extend(options)
             else:
                 mountcmd=["mount", location, self.mountpoint]
-            self.appendCIFSMountOptions(mountcmd)
         # Mount!
         try:
             # For NFS, do a soft mount with tcp as protocol. Since ISO SR is


### PR DESCRIPTION
This patch does a bit of refactoring to set the mount options correctly for
CIFS ISO SRs. This patch sets `cache=none`.

Signed-off-by: Siddharth Vinothkumar <siddharth.vinothkumar@citrix.com>