### PR TITLE
CP-12403: Set backend-kind to vbd for all VDIs in LUNperVDI SRs

### DIFF
--- a/drivers/LUNperVDI.py
+++ b/drivers/LUNperVDI.py
@@ -55,6 +55,7 @@ class RAWVDI(VDI.VDI):
         sm_config = util.default(self, "sm_config", lambda: {})
         sm_config['LUNid'] = str(self.LUNid)
         sm_config['SCSIid'] = self.SCSIid
+        sm_config['backend-kind'] = 'vbd'
         self.sm_config = sm_config
 
     def introduce(self, sr_uuid, vdi_uuid):


### PR DESCRIPTION
When tapdisk3 was introduced in Creedence, we needed to ensure that VDIs in
LUNperVDI SRs continued to be plugged via blkback. This was done for the
RawHBA SR (which overloads the _query() method) but not for the ISCSI SR.

This patch does it on the LUNperVDI class, fixing it for the ISCSI SR.

The fix consists of adding an sm-config key to all VDIs in such an SR
instructing the toolstack to write in a .../vbd/... path instead of the
default .../vbd3/...

Signed-off-by: Felipe Franciosi <felipe@paradoxo.org>