### PR TITLE
CA-92675: Change ISCSI SR scheduler to NOOP

### DIFF
--- a/drivers/ISCSISR.py
+++ b/drivers/ISCSISR.py
@@ -374,12 +374,13 @@ class ISCSISR(SR.SR):
         except:
             pass
 
-        if self.mpath == 'true' and self.dconf.has_key('SCSIid'):
-            self.mpathmodule.refresh(self.dconf['SCSIid'],npaths)
-            # set the device mapper's I/O scheduler
-            path = '/dev/disk/by-scsid/%s' % self.dconf['SCSIid']
-            for file in os.listdir(path):
-                self.block_setscheduler('%s/%s' % (path,file))
+        if self.dconf.has_key('SCSIid'):
+            if self.mpath == 'true':
+                self.mpathmodule.refresh(self.dconf['SCSIid'],npaths)
+            devs = os.listdir("/dev/disk/by-scsid/%s" % self.dconf['SCSIid'])
+            for dev in devs:
+                realdev = os.path.realpath("/dev/disk/by-scsid/%s/%s" % (self.dconf['SCSIid'], dev))
+                util.set_scheduler(realdev.split("/")[-1], "noop")
 
     def detach(self, sr_uuid):
         keys = []


### PR DESCRIPTION
The ISCSI SR works on a LUNperVDI model, attaching a single LUN to a guest
directly via blkback (or tapdisk, in the Rackspace case). Given that a single
task will be issuing requests at any time, it does not make sense to use the
CFQ scheduler for the underlying block devices.

This patch changes the block device (or all block devices, for the multipath
cases, including the device mapper) scheduler(s) to "noop" for the LUNs
related to the SR.

Signed-off-by: Felipe Franciosi <felipe@paradoxo.org>