### PR TITLE
CA-162918: DM-MP - incorrect number of paths during failover and recovery

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -7,6 +7,7 @@
 defaults {
 	user_friendly_names	no
 	dev_loss_tmo		30
+	no_path_retry		0
 }
 blacklist {
 	wwid "*"
@@ -65,5 +66,6 @@ devices {
 		vendor			"NETAPP"
 		product			"LUN.*"
 		dev_loss_tmo    	30
+		no_path_retry		0
 	}
 }


### PR DESCRIPTION
There is a bug in dm-multipath that does not make use of the value supplied
to dev_loss_tmo; it is always set to 'infinity'. Explicitly setting
no_path_retry to 'defaults' overcomes that bug and makes use of the value
supplied.

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>