### PR TITLE
CA-155766 Fix race between lvchange and tap-ctl open

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -41,6 +41,7 @@ from SR import SROSError
 
 import resetvdis
 import vhdutil
+import lvhdutil
 
 # For RRDD Plugin Registration
 from SocketServer import UnixStreamServer
@@ -1547,8 +1548,36 @@ class VDI(object):
             if self.target.has_cap("ATOMIC_PAUSE"):
                 self._attach(sr_uuid, vdi_uuid)
 
-            # Activate the physical node
+            # Take Lock for all chain of VHDS before running
+            # tap-ctl open
+            # Needed to avoid race with lvchange -p which is
+            # now taking the same lock
+            # This is a fix for CA-155766
+            if hasattr(self.target.vdi.sr, 'DRIVER_TYPE') and \
+               self.target.vdi.sr.DRIVER_TYPE == 'lvhd' and \
+               self.target.get_vdi_type() == vhdutil.VDI_TYPE_VHD:
+                lvname = 'VHD-' + vdi_uuid
+                vgname = lvhdutil.VG_PREFIX + sr_uuid
+                util.SMlog("Locking all chain before tap-ctl open")
+                vdiList = vhdutil.getParentChain(lvname,
+                                                 lvhdutil.extractUuid, vgname)
+                lock_list = []
+                for uuid, lvName in vdiList.iteritems():
+                    lock = Lock(uuid, lvhdutil.NS_PREFIX_LVM + sr_uuid)
+                    lock_list.append(lock)
+                    lock.acquire()
+            
+            # Activate the physical node            
             dev_path = self._activate(sr_uuid, vdi_uuid, options)
+
+            # Release Lock for all chain
+            if hasattr(self.target.vdi.sr, 'DRIVER_TYPE') and \
+               self.target.vdi.sr.DRIVER_TYPE == 'lvhd' and \
+               self.target.get_vdi_type() == vhdutil.VDI_TYPE_VHD:
+                util.SMlog("Unlocking all chain after tap-ctl open")
+                for lock in lock_list[::-1]:
+                    lock.release()
+
         except:
             util.SMlog("Exception in activate/attach")
             if self.tap_wanted():

--- a/drivers/lvmcache.py
+++ b/drivers/lvmcache.py
@@ -21,6 +21,7 @@
 import os
 import util
 import lvutil
+import lvhdutil
 from lock import Lock
 from refcounter import RefCounter
 
@@ -218,7 +219,12 @@ class LVMCache:
     def setReadonly(self, lvName, readonly):
         path = self._getPath(lvName)
         if self.lvs[lvName].readonly != readonly:
+            uuids = util.findall_uuid(path)
+            ns = lvhdutil.NS_PREFIX_LVM + uuids[0]
+            lock = Lock(uuids[1], ns)
+            lock.acquire()
             lvutil.setReadonly(path, readonly)
+            lock.release()
             self.lvs[lvName].readonly = readonly
 
     @lazyInit

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -222,6 +222,10 @@ def match_uuid(s):
     regex = re.compile("^[0-9a-f]{8}-(([0-9a-f]{4})-){3}[0-9a-f]{12}")
     return regex.search(s, 0)
 
+def findall_uuid(s):
+    regex = re.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+    return regex.findall(s, 0)
+
 def exactmatch_uuid(s):
     regex = re.compile("^[0-9a-f]{8}-(([0-9a-f]{4})-){3}[0-9a-f]{12}$")
     return regex.search(s, 0)


### PR DESCRIPTION
The new lvm2 code shipped with CentOS 7 has a different
behaviour from the previous one since it de-activates
a logical volume while changing permission from "rw" to
"r". This change implies that if 'lvchange -p r' is executed
whlile a tap-ctl open is happening a volume in the chain can
just disappear and the open fails with the error mentioned
in CA-155766.

I have enforced:

- a lv lock for every lvchange -p
- a lock for every lv in the chain while executing
  tap-ctl open

Signed-off-by: Stefano Panella <stefano.panella@citrix.com>