### PR TITLE
CP-9913: Added originator for xapi login_with_password

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1006,7 +1006,7 @@ class VDI(object):
         import XenAPI
 
         session = XenAPI.xapi_local()
-        session.xenapi.login_with_password('root', '')
+        session.xenapi.login_with_password('root', '', '', 'SM')
 
         target = sm.VDI.from_uuid(session, uuid)
         driver_info = target.sr.srcmd.driver_info
@@ -1448,7 +1448,7 @@ class VDI(object):
             # special pool
             return pool_info
         session = XenAPI.xapi_local()
-        session.xenapi.login_with_password('root', '')
+        session.xenapi.login_with_password('root', '', '', 'SM')
         sr_ref = self.target.vdi.sr.srcmd.params.get('sr_ref')
         sr_config = session.xenapi.SR.get_other_config(sr_ref)
         vdi_config = session.xenapi.VDI.get_other_config(vdi_ref)
@@ -1713,7 +1713,7 @@ class VDI(object):
                 return
 
         session = XenAPI.xapi_local()
-        session.xenapi.login_with_password('root', '')
+        session.xenapi.login_with_password('root', '', '', 'SM')
 
         dev_path = None
         local_sr_uuid = params.get(self.CONF_KEY_CACHE_SR)
@@ -1892,7 +1892,7 @@ class VDI(object):
             return
 
         session = XenAPI.xapi_local()
-        session.xenapi.login_with_password('root', '')
+        session.xenapi.login_with_password('root', '', '', 'SM')
 
         if caching:
             self._remove_cache(session, local_sr_uuid)

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -240,7 +240,7 @@ class XAPI:
     
     def getSession():
         session = XenAPI.xapi_local()
-        session.xenapi.login_with_password(XAPI.USER, '')
+        session.xenapi.login_with_password(XAPI.USER, '', '', 'SM')
         return session
     getSession = staticmethod(getSession)
 

--- a/drivers/coalesce-leaf
+++ b/drivers/coalesce-leaf
@@ -110,7 +110,7 @@ def leaf_coalesce(session, coalesceable_vdis):
 
 def vm_leaf_coalesce(vm_uuid):
     session = XenAPI.xapi_local()
-    session.xenapi.login_with_password('root', '')
+    session.xenapi.login_with_password('root', '', '', 'SM')
 
     messages = []
     vdis = {}

--- a/drivers/lcache.py
+++ b/drivers/lcache.py
@@ -206,7 +206,7 @@ class CacheFileSR(object):
         import XenAPI
 
         session = XenAPI.xapi_local()
-        session.xenapi.login_with_password('root', '')
+        session.xenapi.login_with_password('root', '', '', 'SM')
 
         return cls.from_session(session)
 

--- a/drivers/resetvdis.py
+++ b/drivers/resetvdis.py
@@ -133,7 +133,7 @@ if __name__ == '__main__':
         usage()
 
     session = XenAPI.xapi_local()
-    session.xenapi.login_with_password('root', '')
+    session.xenapi.login_with_password('root', '', '', 'SM')
     mode = sys.argv[1]
     if mode == "all":
         if len(sys.argv) not in [4, 5]:

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -579,7 +579,7 @@ def get_localAPI_session():
     # First acquire a valid session
     session = XenAPI.xapi_local()
     try:
-        session.xenapi.login_with_password('root','')
+        session.xenapi.login_with_password('root', '', '', 'SM')
     except:
         raise xs_errors.XenError('APISession')
     return session

--- a/snapwatchd/snapwatchd
+++ b/snapwatchd/snapwatchd
@@ -137,7 +137,7 @@ def gen_SnapString(dict):
         
 def get_localAPI_session():
     session = XenAPI.xapi_local()
-    session.xenapi.login_with_password('root','')
+    session.xenapi.login_with_password('root', '', '', 'SM')
     return session
 
 def _getDevUUIDlist(h,uuid):


### PR DESCRIPTION
The login_with_password XenAPI call takes an "originator"
string as its fourth parameter.

If a client does this, then it gets its own pool of xapi sessions.
Moreover it will not have its xapi sessions destroyed prematurely
as a result of some other misbehaving client that keeps creating
sessions and not logging out of them.

This patch adds the "originator" to all invokes of
login_with_password.

Signed-off-by: Koushik Chakravarty <koushik.chakravarty@citrix.com>