### PR TITLE
CA-174104: Setting LVM_SYSTEM_DIR to the correct value for trim

### DIFF
--- a/drivers/trim_util.py
+++ b/drivers/trim_util.py
@@ -38,6 +38,7 @@ ERROR_CODE_KEY = "errcode"
 ERROR_MSG_KEY = "errmsg"
 
 TRIM_LAST_TRIGGERED_KEY = "trim_last_triggered"
+MASTER_LVM_CONF = '/etc/lvm/master'
 
 def _vg_by_sr_uuid(sr_uuid):
     return lvhdutil.VG_PREFIX + sr_uuid
@@ -85,6 +86,7 @@ def do_trim(session, args):
     """Attempt to trim the given LVHDSR"""
     util.SMlog("do_trim: %s" % args)
     sr_uuid = args["sr_uuid"]
+    os.environ['LVM_SYSTEM_DIR'] = MASTER_LVM_CONF
 
     if TRIM_CAP not in util.sr_get_capability(sr_uuid):
         util.SMlog("Trim command ignored on unsupported SR %s" % sr_uuid)


### PR DESCRIPTION
Commands like lvcreate and lvremove invoked as part of trim do
not work, since LVM_SYSTEM_DIR is not being set to the correct
value in the code. Setting this environment variable to the
correct value, allows modification of vg metadata.

Signed-off-by: Pritha Srivastava <pritha.srivastava@citrix.com>