### PR TITLE
CA-136790: Ensure consistent behaviour of get_devices_by_SCSIid

### DIFF
--- a/drivers/scsiutil.py
+++ b/drivers/scsiutil.py
@@ -180,7 +180,10 @@ def getdev(path):
     return os.path.realpath(newpath).split('/')[-1]
 
 def get_devices_by_SCSIid(SCSIid):
-    return os.listdir(os.path.join('/dev/disk/by-scsid', SCSIid))
+    devices = os.listdir(os.path.join('/dev/disk/by-scsid', SCSIid))
+    if 'mapper' in devices:
+        devices.remove('mapper')
+    return devices
 
 def rawdev(dev):
     return re.sub("[0-9]*$","",getdev(dev))


### PR DESCRIPTION
Dependant on the udev rules there may be a mapper device in by-scsid. This
commit ensures that that get_devices_by_SCSIid never returns the mapper-device.

Signed-off-by: Robert Breker <robert.breker@citrix.com>
Reviewed-by: Keith Petley <keith.petley@citrix.com>

(cherry picked from commit 68010a2016938f118e810f9ce78b60489f90729a)
Fixes CA-172756.
Imported-by: Pritha Srivastava <pritha.srivastava@citrix.com>