### PR TITLE
CP-13187: Disable usage of OCFS SRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,8 @@ install: precheck
 	cd $(SM_STAGING)$(SM_DEST) && rm -f LVHDoISCSISR && ln -sf LVHDoISCSISR.py LVMoISCSISR
 	cd $(SM_STAGING)$(SM_DEST) && rm -f LVHDoHBASR && ln -sf LVHDoHBASR.py LVMoHBASR
 	cd $(SM_STAGING)$(SM_DEST) && rm -f OCFSSR
+	cd $(SM_STAGING)$(SM_DEST) && rm -f OCFSoISCSISR
+	cd $(SM_STAGING)$(SM_DEST) && rm -f OCFSoHBASR
 	ln -sf $(SM_DEST)mpathutil.py $(SM_STAGING)/sbin/mpathutil
 	install -m 755 drivers/02-vhdcleanup $(SM_STAGING)$(MASTER_SCRIPT_DEST)
 	install -m 755 drivers/lvhd-thin $(SM_STAGING)$(PLUGIN_SCRIPT_DEST)

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -118,11 +118,9 @@ cp -f /etc/lvm/lvm.conf.orig /etc/lvm/lvm.conf || exit $?
 /opt/xensource/sm/OCFSSR.py
 /opt/xensource/sm/OCFSSR.pyc
 /opt/xensource/sm/OCFSSR.pyo
-/opt/xensource/sm/OCFSoISCSISR
 /opt/xensource/sm/OCFSoISCSISR.py
 /opt/xensource/sm/OCFSoISCSISR.pyc
 /opt/xensource/sm/OCFSoISCSISR.pyo
-/opt/xensource/sm/OCFSoHBASR
 /opt/xensource/sm/OCFSoHBASR.py
 /opt/xensource/sm/OCFSoHBASR.pyc
 /opt/xensource/sm/OCFSoHBASR.pyo


### PR DESCRIPTION
Removed symlinks to OCFSoHBASR and OCFSoISCSISR so that they can't be used.

Signed-off-by: Jorge Martin <jorge.martin@citrix.com>