### PR TITLE
CA-180792: Enable ALUA autodetection and group_by_prio for VPLEX

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -42,6 +42,13 @@ devices {
 		retain_attached_hw_handler yes
 	}
 	device {
+		vendor			"EMC"
+		product			"Invista"
+		detect_prio		yes
+		retain_attached_hw_handler yes
+		path_grouping_policy	group_by_prio
+	}
+	device {
 		vendor			"EQLOGIC"
 		product			"100E-00"
 		path_grouping_policy	multibus


### PR DESCRIPTION
In CA-141002 we have enabled ALUA autodetection for VNX. This commit enables
the same capability as well for VPLEX.
In addition to enable the autodetection, this commit also changes the
path_grouping_policy to group_by_prio, as the current upstream setting
multibus wouldn't make sense for ALUA.

The partner has completed the qualification of the updated multipath
configuration with their storage arrays. They have tested both, ALUA and
legacy mode.

Signed-off-by: Robert Breker <robert.breker@citrix.com>