### PR TITLE
CA-181447: Fix checking of node minor

### DIFF
--- a/multipath/sm-multipath
+++ b/multipath/sm-multipath
@@ -71,7 +71,8 @@ start() {
 		ROOT_DISK_MINOR=${ROOT_PART_SLAVE#dm-}
 		MPATH_NODES="$(dmsetup ls --target multipath --exec ls)"
 		for n in $MPATH_NODES ; do
-			NODE_MINOR="$(stat -L --format=%T $n)"
+			# stat %T returns value in hex, convert to decimal before comparing
+			NODE_MINOR="$((0x$(stat -L --format=%T $n)))"
 			if [ "$ROOT_DISK_MINOR" = "$NODE_MINOR" ] ; then
 				mkdir -p /dev/disk/mpInuse
 				ln -sf $n /dev/disk/mpInuse


### PR DESCRIPTION
stat --format=%T returns minor device type in hex and this value is compared
against ROOT_DISK_MINOR which is decimal. Convert value returned by stat %T
to decimal, before doing the comparison.

Signed-off-by: Anoob Soman <anoob.soman@citrix.com>
Reviewed-by: Germano Percossi <germano.percossi@citrix.com>