### PR TITLE
CA-136041: Multipathd forgets faulty paths after an SR operation

### DIFF
--- a/drivers/mpath_dmp.py
+++ b/drivers/mpath_dmp.py
@@ -122,14 +122,22 @@ def _resetDMP(sid,explicit_unmap=False,delete_nodes=False):
         except:
             util.SMlog("WARNING: exception raised while attempting to"
                        " modify multipath.conf")
-        try:
+
+# Overriding delete_nodes value to True, since reconfigure does not drop
+# devices that are faulty during pbd unplug and plug. They remain 
+# the system which prevents creation of new maps. This setting is valid only 
+# for any SR operation done before dev_loss_tmo, post which the device is
+# automatically dropped by the kernal.
+        
+	delete_nodes=True
+	devices = mpath_cli.list_paths(sid)
+	try:
             mpath_cli.reconfigure()
         except:
             util.SMlog("WARNING: exception raised while attempting to"
                        " reconfigure")
         time.sleep(5)
 
-        devices = mpath_cli.list_paths(sid)
 
         try:
             mpath_cli.remove_map(sid)


### PR DESCRIPTION
The operations pbd-plug and -unplug cause 'multipathd -k "reconfigure"'.
During reconfigure all(!) maps are deleted and re-created. Multipathd
re-creates maps without paths that are temporarily down when doing this.
These paths will only restore if they timeout beyond their dev_loss_tmo
and get re-added later, as this triggers the multipathd behaviour for new
devices. Hence, any SR operation done before dev_loss_tmo the faulty paths
are lost and never added. The fix to this problem is two fold -

a) multipathd reconfigure has been modified to include even faulty paths
 while recreating maps

b) devices have to be deleted from system when SR operations are performed
 before dev_loss_tmo

Signed-off-by: Sharath Babu <sharath.babu@citrix.com>

