### PR TITLE
CA-182713  : lvm.conf file is wrong in some systems

### DIFF
--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -61,8 +61,12 @@ exit 0
 
 %postun
 %systemd_postun make-dummy-sr.service
-[ ! -d /etc/lvm/master ] || rm -Rf /etc/lvm/master || exit $?
-cp -f /etc/lvm/lvm.conf.orig /etc/lvm/lvm.conf || exit $?
+if [ $1 -eq 0 ]; then
+    [ ! -d /etc/lvm/master ] || rm -Rf /etc/lvm/master || exit $?
+    cp -f /etc/lvm/lvm.conf.orig /etc/lvm/lvm.conf || exit $?
+elif [ $1 -eq 1 ]; then
+    true; 
+fi
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
    This happens only when we upgrade SM rpm. During an upgrade, after installation
    of the new package, old package is removed and %postun is called. In %postun
    all changes done to the lvm.conf file gets reset to lvm.conf.orig which is the
    expected behavior during package uninstall and not during package upgrade. As
    a fix to this issue a logic is added in %postun to differentiate between package
    uninstall and package upgrade. This prevents lvm.conf to be reset during a
    package upgrade.

    Signed-off-by: Sharath Babu <sharath.babu@citrix.com>
