### PR TITLE
CA-167972 - Do not enable read cache on Suspend VDI when resuming

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1008,6 +1008,9 @@ class VDI(object):
             util.SMlog(self.target.vdi)
             self.__o_direct = True
             self.__o_direct_reason = "NO_RO_IMAGE"
+        elif options.get("rdonly") and not self.target.vdi.parent:
+            self.__o_direct = True
+            self.__o_direct_reason = "RO_WITH_NO_PARENT"
         elif options.get(self.CONF_KEY_O_DIRECT):
             self.__o_direct = True
             self.__o_direct_reason = "SR_OVERRIDE"


### PR DESCRIPTION
The toolstack opened the Suspend VDI as read-only when resuming and
the VDI did not have a parent. This caused the old read cache enable
logic to allow read caching on the VDI.

Read caching is not as efficient as direct IO for the first read of
the data. This is due to the filesystem cache breaking large read
requests into smaller parts. Additionally, it is not worth using
the cache for data which is read once only ( which is the case for
resuming from a suspend VDI ).

This patch splits detecting a VDI with no parent out to seperate
conditional and returns a different error string to make it clearer
why read caching was not enabled.

Signed-off-by: Malcolm Crossley <malcolm.crossley@citrix.com>