### PR TITLE
CA-184022 : Exception happening in _deactivate_locked cause

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1960,14 +1960,10 @@ class VDI(object):
             util.SMlog("ERROR: Local cache SR not specified, ignore")
             return
 
-        session = XenAPI.xapi_local()
-        session.xenapi.login_with_password('root', '', '', 'SM')
-
         if caching:
-            self._remove_cache(session, local_sr_uuid)
+            self._remove_cache(self._session, local_sr_uuid)
 
-        self._updateCacheRecord(session, self.target.vdi.uuid, None, None)
-        session.xenapi.session.logout()
+        self._updateCacheRecord(self._session, self.target.vdi.uuid, None, None)
 
     def _is_tapdisk_in_use(self, minor):
         (retVal, links) = util.findRunningProcessOrOpenFile("tapdisk")


### PR DESCRIPTION
backend link not to be removed

This exception occus when the network buffer gets filled. Python
server reads the data from the buffer in chunks and not as a whole.
Hence, during heavy traffic conditions the server is forced to advertise
the receiving window size as '0' multiple times which terminates the
connection at the remote end.

As a fix we create a session inside a loop with a fixed amount of tries,
this will introduce sufficient delay for the buffer to get cleared and a
session to be created. Keeping in mind scalability we can additionally introduce
a short delay. This error is bound to occur across XenServer where ever we are
trying to create a session, hence it would be good to foresee this issue and handle
it everytime we create a new session and the same has been done.

Signed-off-by: Sharath Babu <sharath.babu@citrix.com>