### PR TITLE
CA-186487: Normalize SMB mount paths

### DIFF
--- a/drivers/CIFSSR.py
+++ b/drivers/CIFSSR.py
@@ -211,7 +211,7 @@ class CIFSSR(FileSR.FileSR):
                 raise CifsException("rmdir failed with error '%s'" % inst.strerror)
 
     def __extract_server(self):
-        return self.remoteserver[2:]
+        return self.remoteserver[2:].replace('\\', '/')
 
     def __check_license(self):
         """Raises an exception if CIFS is not licensed."""


### PR DESCRIPTION
Convert all back slashes in share path to forward slashes
for consistency. 

Signed-off-by: Chandrika Srinivasan <chandrika.srinivasan@citrix.com>