### PR TITLE
CA-192760: use noop scheduler for multipath devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ SM_LIBS += wwid_conf
 SM_LIBS += trim_util
 SM_LIBS += pluginutil
 
-UDEV_RULES = 39-multipath 40-multipath 55-xs-mpath-scsidev 58-xapi
+UDEV_RULES = 39-multipath 40-multipath 55-xs-mpath-scsidev 58-xapi 90-xs-ioscheduler
 MPATH_DAEMON = sm-multipath
 MPATH_CONF = multipath.conf
 CIFS_CONF = cifs.conf

--- a/drivers/SR.py
+++ b/drivers/SR.py
@@ -189,6 +189,8 @@ class SR(object):
 
         return target(cmd, sr_uuid)
 
+
+    @util.disabled("udev rules")
     def block_setscheduler(self, dev):
         try:
             realdev = os.path.realpath(dev)

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -73,6 +73,33 @@ class SRBusyException(SMException):
     """The SR could not be locked"""
     pass
 
+
+def disabled(reason = None):
+    """This function is used as decorator to deprecate functions.
+
+    It does that by making the decorated function a no-op and printing
+    a warning message in the logs.
+    It is possible to pass an optional parameter to explain why it was
+    replaced (if replaced).
+
+    For example:
+      @disabled("foo function")
+    will add to the message ": use foo function instead"
+    """
+    if reason:
+        str_append = ": use {} instead".format(reason)
+    else:
+        str_append = ""
+
+    def disabled_decor(fun):
+        SMlog("WARNING: {} has been disabled{}".format(fun.__name__,
+                                                        str_append))
+        def wrapper(*args, **kwargs):
+            pass
+        return wrapper
+    return disabled_decor
+
+
 def logException(tag):
     info = sys.exc_info()
     if info[0] == exceptions.SystemExit:
@@ -995,6 +1022,8 @@ def dom0_disks():
     SMlog("Dom0 disks: %s" % disks)
     return disks
 
+
+@disabled("udev rules")
 def set_scheduler(dev, str):
     devices = []
     if not scsiutil.match_dm(dev):

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -296,6 +296,7 @@ fi
 %config /etc/udev/rules.d/40-multipath.rules
 %config /etc/udev/rules.d/55-xs-mpath-scsidev.rules
 %config /etc/udev/rules.d/58-xapi.rules
+%config /etc/udev/rules.d/90-xs-ioscheduler.rules
 %config /etc/multipath.xenserver/multipath.conf
 %config /etc/udev/rules.d/69-dm-lvm-metad.rules
 %config /etc/modprobe.d/cifs.conf

--- a/udev/90-xs-ioscheduler.rules
+++ b/udev/90-xs-ioscheduler.rules
@@ -1,0 +1,24 @@
+SUBSYSTEM!="block", GOTO="xs_ioscheduler_end"
+
+# Take care of physical devices
+KERNEL=="sd*", GOTO="xs_ioscheduler_sd"
+
+# Multipath devices have their own scheduler unlike
+# LVM ones, so make sure their defaults are right.
+# We use a property set by a previous dm rule not by the kernel
+ENV{DM_UUID}=="mpath-?*", GOTO="xs_ioscheduler_action"
+
+# Not interested any more
+GOTO="xs_ioscheduler_end"
+
+# Not interested in partitions and root device.
+# For the time being we assume root is on the ATA bus.
+LABEL="xs_ioscheduler_sd"
+END{ID_BUS}=="ata", GOTO="xs_ioscheduler_end"
+ENV{DEVTYPE}=="partition", GOTO="xs_ioscheduler_end"
+
+# Now set the scheduler
+LABEL="xs_ioscheduler_action"
+ACTION=="add|change", ATTR{queue/scheduler}="noop"
+
+LABEL="xs_ioscheduler_end"


### PR DESCRIPTION
Patch not ready to be pushed.
The following is pending:
* Check if current behaviour (we do set this in storage manager) is really broken. The fact
 that a slave device is set with an elevator different than the multipath dm devices does not necessarily
 mean the kernel is taking that elevator really into account
* We need a better way to understand locally attached and root devices
* We could add a check for non rotational disks