### PR TITLE
CA-195426: Add 'guest' to CIFS mount options to avoid password prompt

### DIFF
--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -284,6 +284,7 @@ class ISOSR(SR.SR):
         try:
             options.append(self.getCIFSPasswordOptions())
             options.append(self.getCacheOptions())
+            options.append('guest')
         except:
             util.SMlog("Exception while attempting to append mount options")
             raise

--- a/drivers/SMBSR.py
+++ b/drivers/SMBSR.py
@@ -129,7 +129,8 @@ class SMBSR(FileSR.FileSR):
                 'sec=ntlm',
                 'cache=none',
                 'vers=3.0',
-                'credentials=%s' % self.credentials
+                'credentials=%s' % self.credentials,
+                'guest'
         ])
 
         dom_username = self.dconf['username'].split('\\')


### PR DESCRIPTION
Signed-off-by: Chandrika Srinivasan <chandrika.srinivasan@citrix.com>