### PR TITLE
CA-198593: Do not assume N iscsi connections means N devices

### DIFF
--- a/drivers/ISCSISR.py
+++ b/drivers/ISCSISR.py
@@ -376,7 +376,7 @@ class ISCSISR(SR.SR):
 
         if self.dconf.has_key('SCSIid'):
             if self.mpath == 'true':
-                self.mpathmodule.refresh(self.dconf['SCSIid'],npaths)
+                self.mpathmodule.refresh(self.dconf['SCSIid'], 0)
             devs = os.listdir("/dev/disk/by-scsid/%s" % self.dconf['SCSIid'])
             for dev in devs:
                 realdev = os.path.realpath("/dev/disk/by-scsid/%s/%s" % (self.dconf['SCSIid'], dev))


### PR DESCRIPTION
Some filers expose iscsi connections but only some of them
can be used to reach a specific device.
For example, we could have 2 iscsi connections with same IQN
but different IP but only one of those is exposing the device
with the SCSI id we are looking for.

We refcount the number of iscsi sessions we initiate to
make sure another SR using the same iscsi connections
will not be disrupted by another SR's detach.
To this end, we count how many connections we open.

Assuming that this number must match the number of paths
to a specific device, is wrong, though.

All the other SRs, in fact, do not care and call
mpathmodule.refresh with "0" meaning "not sure about how
many paths you should find".

Signed-off-by: Germano Percossi <germano.percossi@citrix.com>