### PR TITLE
CA-205120: do not start sm-multipath upon RPM installation

### DIFF
--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -32,7 +32,6 @@ rm -rf $RPM_BUILD_ROOT
 %post
 [ ! -x /sbin/chkconfig ] || chkconfig --add mpathroot
 [ ! -x /sbin/chkconfig ] || chkconfig --add sm-multipath
-service sm-multipath start
 %systemd_post make-dummy-sr.service
 %systemd_post snapwatchd.service
 


### PR DESCRIPTION
We need sm-multipath to be started only at boot when we
check if the root device is multipathed or not.

During system installation it throws harmless but
annoying errors.

Signed-off-by: Germano Percossi germano.percossi@citrix.com
