### PR TITLE
Fix LVM unit tests.

### DIFF
--- a/tests/lvmlib.py
+++ b/tests/lvmlib.py
@@ -1,4 +1,6 @@
 import optparse
+import lvutil
+import os
 
 
 class LogicalVolume(object):
@@ -29,8 +31,8 @@ class LVSubsystem(object):
         self.logger = logger
         self.lv_calls = []
         self._volume_groups = []
-        executable_injector('/usr/sbin/lvcreate', self.fake_lvcreate)
-        executable_injector('/usr/sbin/lvremove', self.fake_lvremove)
+        executable_injector(os.path.join(lvutil.LVM_BIN, 'lvcreate'), self.fake_lvcreate)
+        executable_injector(os.path.join(lvutil.LVM_BIN, 'lvremove'), self.fake_lvremove)
         executable_injector('/sbin/dmsetup', self.fake_dmsetup)
 
     def add_volume_group(self, name):

--- a/tests/test_lvmlib.py
+++ b/tests/test_lvmlib.py
@@ -1,5 +1,6 @@
 import unittest
 import mock
+import os
 
 import lvmlib
 
@@ -21,9 +22,10 @@ class TestLVSubSystem(unittest.TestCase, ExecResultMixIn):
         executable_injector = mock.Mock()
 
         lvsubsystem = lvmlib.LVSubsystem(None, executable_injector)
+        lvcreate_path = os.path.join(lvmlib.lvutil.LVM_BIN, 'lvcreate')
 
         self.assertTrue(
-            mock.call('/usr/sbin/lvcreate', lvsubsystem.fake_lvcreate)
+            mock.call(lvcreate_path, lvsubsystem.fake_lvcreate)
             in executable_injector.mock_calls
         )
 
@@ -31,9 +33,10 @@ class TestLVSubSystem(unittest.TestCase, ExecResultMixIn):
         executable_injector = mock.Mock()
 
         lvsubsystem = lvmlib.LVSubsystem(None, executable_injector)
+        lvremove_path = os.path.join(lvmlib.lvutil.LVM_BIN, 'lvremove')
 
         self.assertTrue(
-            mock.call('/usr/sbin/lvremove', lvsubsystem.fake_lvremove)
+            mock.call(lvremove_path, lvsubsystem.fake_lvremove)
             in executable_injector.mock_calls
         )
 


### PR DESCRIPTION
The UT depend on a specific path for lvcreate binaries, however
the path actually used is distro dependent.  On Debian distros,
lvcreate is in /sbin.  SM correctly auto detects the location,
but the UT were expecting it in /usr/sbin.

Fix the UT so they use the detected path for the executables.