### PR TITLE
CA-169953: Enable read caching on SMB SRs

### DIFF
--- a/drivers/SMBSR.py
+++ b/drivers/SMBSR.py
@@ -145,8 +145,9 @@ class SMBSR(FileSR.FileSR):
     def getMountOptions(self):
         """Creates option string based on parameters provided"""
         options = ['sec=ntlm',
-                'cache=none',
-                'vers=3.0'
+                'cache=loose',
+                'vers=3.0',
+                'actimeo=0'
         ]
 
         if self.dconf.has_key('username') and \

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1002,7 +1002,7 @@ class VDI(object):
         if util.read_caching_is_restricted(self._session):
             self.__o_direct = True
             self.__o_direct_reason = "LICENSE_RESTRICTION"
-        elif not ((self.target.vdi.sr.handles("nfs") or self.target.vdi.sr.handles("ext"))):
+        elif not ((self.target.vdi.sr.handles("nfs") or self.target.vdi.sr.handles("ext") or self.target.vdi.sr.handles("smb"))):
             self.__o_direct = True
             self.__o_direct_reason = "SR_NOT_SUPPORTED"
         elif not (options.get("rdonly") or self.target.vdi.parent):


### PR DESCRIPTION
Setting cache=loose enables read caching.
Setting actimeo=0 prevents attribute caching.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>
Reviewed-by: Chandrika Srinivasan <chandrika.srinivasan@citrix.com>