### PR TITLE
CA-212295: Stale Refcount files on pool slaves after coalescing

### DIFF
--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -728,7 +728,7 @@ class LVHDSR(SR.SR):
                 lvname = os.path.basename(fileName.replace('-','/').\
                                           replace('//', '-'))
                 lvname = os.path.join(self.path, lvname)
-                util.silent_noent(lvname)
+                util.force_unlink(lvname)
             except Exception, e:
                 util.SMlog("LVHDSR.detach: failed to remove the symlink for " \
                            "file %s. Error: %s" % (fileName, str(e)))

--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -1862,7 +1862,7 @@ class SR:
         util.fistpoint.activate("LVHDRT_coaleaf_one_renamed", self.uuid)
         vdi.parent.rename(vdiUuid)
         util.fistpoint.activate("LVHDRT_coaleaf_both_renamed", self.uuid)
-        self._updateSlavesOnRename(vdi.parent, oldName)
+        self._updateSlavesOnRename(vdi.parent, oldName, origParentUuid)
 
         # Note that "vdi.parent" is now the single remaining leaf and "vdi" is 
         # garbage
@@ -1917,7 +1917,7 @@ class SR:
     def _updateSlavesOnUndoLeafCoalesce(self, parent, child):
         pass
 
-    def _updateSlavesOnRename(self, vdi, oldName):
+    def _updateSlavesOnRename(self, vdi, oldName, origParentUuid):
         pass
 
     def _updateSlavesOnResize(self, vdi):
@@ -2427,7 +2427,7 @@ class LVHDSR(SR):
         args = {"vgName" : self.vgName,
                 "action1": "deactivateNoRefcount",
                 "lvName1": vdi.fileName,
-                "action2": "cleanupLock",
+                "action2": "cleanupLockAndRefcount",
                 "uuid2"  : vdi.uuid,
                 "ns2"    : lvhdutil.NS_PREFIX_LVM + self.uuid}
         onlineHosts = self.xapi.getOnlineHosts()
@@ -2470,7 +2470,7 @@ class LVHDSR(SR):
                     slave, self.xapi.PLUGIN_ON_SLAVE, "multi", args)
             Util.log("call-plugin returned: '%s'" % text)
 
-    def _updateSlavesOnRename(self, vdi, oldNameLV):
+    def _updateSlavesOnRename(self, vdi, oldNameLV, origParentUuid):
         slaves = util.get_slaves_attached_on(self.xapi.session, [vdi.uuid])
         if not slaves:
             Util.log("Update-on-rename: VDI %s not attached on any slave" % vdi)
@@ -2480,7 +2480,10 @@ class LVHDSR(SR):
                 "action1": "deactivateNoRefcount",
                 "lvName1": oldNameLV,
                 "action2": "refresh",
-                "lvName2": vdi.fileName}
+                "lvName2": vdi.fileName,
+                "action3": "cleanupLockAndRefcount",
+                "uuid3"  : origParentUuid,
+                "ns3"    : lvhdutil.NS_PREFIX_LVM + self.uuid}
         for slave in slaves:
             Util.log("Updating %s to %s on slave %s" % \
                     (oldNameLV, vdi.fileName, slave))

--- a/drivers/on-slave
+++ b/drivers/on-slave
@@ -54,8 +54,11 @@ def multi(session, args):
                 util.SMlog("on-slave.deactivateNoRefcount failed")
         elif action == "refresh":
             lvmCache.activateNoRefcount(args["lvName%d" % i], True)
-        elif action == "cleanupLock":
+        elif action == "cleanupLockAndRefcount":
+            from refcounter import RefCounter
+
             lock.Lock.cleanup(args["uuid%d" % i], args["ns%d" % i])
+            RefCounter.reset(args["uuid%d" % i], args["ns%d" % i])
         else:
             raise util.SMException("unrecognized action: %s" % action)
         i += 1

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -404,9 +404,9 @@ def pathexists(path):
             raise CommandException(errno.EIO, "os.stat(%s)" % path, "failed")
         return False
 
-def silent_noent(fn, func=os.unlink):
+def force_unlink(path):
     try:
-        func(fn)
+        os.unlink(path)
     except OSError, e:
         if e.errno != errno.ENOENT:
             raise


### PR DESCRIPTION
Force unlink a VHD's refcount in cleanup.LVHDSR.deleteVDI()
on all pool slaves.

Signed-off-by: Kostas Ladopoulos <Konstantinos.Ladopoulos@citrix.com>