### PR TITLE
CA-212761: Use eth field in probe data conditionally

### DIFF
--- a/drivers/devscan.py
+++ b/drivers/devscan.py
@@ -328,7 +328,7 @@ def scan(srobj):
         obj.id = ids[3]
         obj.lun = ids[4]
         obj.hba = hba['procname']
-        if hba['eth']:
+        if hba.has_key('eth') and hba['eth']:
             obj.eth = hba['eth']
         obj.numpaths = 1
         if vdis.has_key(obj.SCSIid):


### PR DESCRIPTION
Not all adapters have 'eth' field populated in their probe data.
Check for the existence of the field in the structure before
extracting the value for display.

Signed-off-by: Chandrika Srinivasan <chandrika.srinivasan@citrix.com>