### PR TITLE
CA-213065: Need to import sys if we read exception data.

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -20,6 +20,7 @@
 
 
 import os
+import sys
 import re
 import time
 import copy


### PR DESCRIPTION
From: Mark Syms mark.syms@citrix.com
