### PR TITLE
CA-214746: made snapwatchd service not executable

### DIFF
--- a/snapwatchd/Makefile
+++ b/snapwatchd/Makefile
@@ -14,7 +14,6 @@ install: xslib.py snapwatchd snapdebug.py
 	chmod +x $(DESTDIR)$(PREFIX)/snapdebug.py
 	mkdir -p $(DESTDIR)$(SYSTEMD_SERVICE_DIR)
 	cp snapwatchd.service $(DESTDIR)$(SYSTEMD_SERVICE_DIR)/.
-	chmod +x $(DESTDIR)$(SYSTEMD_SERVICE_DIR)/snapwatchd.service
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
daemon.log file complained that snapwatchd.service
file was marked as executable and it said that
executable permission bits had to be removed

Signed-off-by: Letsibogo Ramadi <letsibogo.ramadi@citrix.com>