### PR TITLE
CA-198309: Cleanup locking files after inline vdi delete

### DIFF
--- a/drivers/FileSR.py
+++ b/drivers/FileSR.py
@@ -572,6 +572,7 @@ class FileVDI(VDI.VDI):
         self.sr.deleted_vdi(vdi_uuid)
         self._db_forget()
         self.sr._update(self.sr.uuid, -self.size)
+        self.sr.lock.cleanupAll(vdi_uuid)
         self.sr._kickGC()
         
     def attach(self, sr_uuid, vdi_uuid):

--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -1412,6 +1412,8 @@ class LVHDVDI(VDI.VDI):
 
         try:
             self.sr.lvmCache.remove(self.lvname)
+            self.sr.lock.cleanup(vdi_uuid, lvhdutil.NS_PREFIX_LVM + sr_uuid)
+            self.sr.lock.cleanupAll(vdi_uuid)
         except SR.SRException, e:
             util.SMlog(
                 "Failed to remove the volume (maybe is leaf coalescing) "


### PR DESCRIPTION
This is adding the necessary locking files cleanup which was missed
during commit 9d82cecfe7a4a65bfdcd451235587c449c675923 ([CA-183960]
[CA-196882]: GC in batch mode and immediate deletes in SRs).

This has been tested on EXT and LVM local SR, where LVM local SR was
the environment used when the resource leak was found.

A further refactoring of the file locking lifecycle could be considered
but could also add significant risk which maybe we do not want to take
at this time.

Signed-off-by: Stefano Panella <stefano.panella@citrix.com>