### PR TITLE
CA-219124: Wait for NFS service to be up before attempting mount

### DIFF
--- a/tests/test_nfs.py
+++ b/tests/test_nfs.py
@@ -18,6 +18,13 @@ class Test_nfs(unittest.TestCase):
 
         pread.assert_called_once_with(['/usr/sbin/rpcinfo', '-p', 'aServer'], quiet=False)
 
+    @mock.patch('util.pread')
+    def test_check_server_service(self, pread):
+        nfs.check_server_service('aServer')
+
+        pread.assert_called_once_with(['/usr/sbin/rpcinfo', '-t', 
+                                       'aServer', 'nfs'])
+
     def get_soft_mount_pread(self, binary, vers):
         return ([binary, 'remoteserver:remotepath', 'mountpoint', '-o',
                  'soft,timeo=600,retrans=2147483647,proto=transport,'
@@ -25,30 +32,38 @@ class Test_nfs(unittest.TestCase):
                 )
 
     @mock.patch('util.makedirs')
+    @mock.patch('nfs.check_server_service')
     @mock.patch('util.pread')
-    def test_soft_mount(self, pread, makedirs):
+    def test_soft_mount(self, pread, check_server_service, makedirs):
         nfs.soft_mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
                        timeout=0)
 
+        check_server_service.assert_called_once_with('remoteserver')
         pread.assert_called_once_with(self.get_soft_mount_pread('mount.nfs',
                                                                 '3'))
 
     @mock.patch('util.makedirs')
+    @mock.patch('nfs.check_server_service')
     @mock.patch('util.pread')
-    def test_soft_mount_nfsversion_3(self, pread, makedirs):
+    def test_soft_mount_nfsversion_3(self, pread, 
+                                     check_server_service, makedirs):
         nfs.soft_mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
                        timeout=0, nfsversion='3')
 
-        pread.assert_called_once_with(self.get_soft_mount_pread('mount.nfs',
+        check_server_service.assert_called_once_with('remoteserver')
+        pread.assert_called_with(self.get_soft_mount_pread('mount.nfs',
                                                                 '3'))
 
     @mock.patch('util.makedirs')
+    @mock.patch('nfs.check_server_service')
     @mock.patch('util.pread')
-    def test_soft_mount_nfsversion_4(self, pread, makedirs):
+    def test_soft_mount_nfsversion_4(self, pread, 
+                                     check_server_service, makedirs):
         nfs.soft_mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
                        timeout=0, nfsversion='4')
 
-        pread.assert_called_once_with(self.get_soft_mount_pread('mount.nfs4',
+        check_server_service.assert_called_once_with('remoteserver')
+        pread.assert_called_with(self.get_soft_mount_pread('mount.nfs4',
                                                                 '4'))
 
     def test_validate_nfsversion_invalid(self):


### PR DESCRIPTION
Added wait (maximum of 3 minutes) for availability of NFS service
before attempting mount of NFS SR. Without this an NFS mount fails
immediately and an absence of retries leaves the NFS SR in a failed state. 

Signed-off-by: Chandrika Srinivasan <chandrika.srinivasan@citrix.com>