### PR TITLE
CA-226070 Switched on logging for snapwatchd daemon

### DIFF
--- a/snapwatchd/snapwatchd.service
+++ b/snapwatchd/snapwatchd.service
@@ -4,7 +4,7 @@ After=syslog.target network.target
 
 [Service]
 Type=simple
-ExecStart=/opt/xensource/sm/snapwatchd/snapwatchd -f
+ExecStart=/opt/xensource/sm/snapwatchd/snapwatchd -f -d
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Some XenRT tescases depend on snapwatchd daemon logs
in SMLog

Signed-off-by: Letsibogo Ramadi <letsibogo.ramadi@citrix.com>