### PR TITLE
CA-222525: specify SMB protocol version 2.0 to avoid SMB1 retry failure

### DIFF
--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -294,6 +294,7 @@ class ISOSR(SR.SR):
             options.append(self.getCIFSPasswordOptions())
             options.append(self.getCacheOptions())
             options.append('guest')
+            options.append('vers=2.0')
         except:
             util.SMlog("Exception while attempting to append mount options")
             raise


### PR DESCRIPTION
From: Mark Syms <mark.syms@citrix.com>

Signed-off-by: Mark Syms <mark.syms@citrix.com>