### PR TITLE
Fix different multipath related issues (CP-19247 and CA-234893)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,8 @@ install: precheck
 	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
 	install -m 644 etc/make-dummy-sr.service \
 	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
+	install -m 644 multipath/mpcount.service \
+	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
 	install -m 644 snapwatchd/snapwatchd.service \
 	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
 	for i in $(UDEV_RULES); do \
@@ -202,6 +204,7 @@ install: precheck
 	ln -sf $(SM_DEST)lcache.py $(SM_STAGING)$(BIN_DEST)tapdisk-cache-stats
 	ln -sf /dev/null $(SM_STAGING)$(UDEV_RULES_DIR)/69-dm-lvm-metad.rules
 	install -m 755 scripts/xs-mpath-scsidev.sh $(SM_STAGING)$(UDEV_SCRIPTS_DIR)
+	install -m 755 scripts/udevmpath.sh $(SM_STAGING)$(UDEV_SCRIPTS_DIR)
 	install -m 755 scripts/xe-get-arrayid-lunnum $(SM_STAGING)$(BIN_DEST)
 	install -m 755 scripts/xe-getarrayidentifier $(SM_STAGING)$(BIN_DEST)
 	install -m 755 scripts/xe-getlunidentifier $(SM_STAGING)$(BIN_DEST)

--- a/drivers/mpathcount.py
+++ b/drivers/mpathcount.py
@@ -35,10 +35,9 @@ mpp_path_update = False
 match_bySCSIid = False
 
 util.daemon()
-if len(sys.argv) > 1:
+if len(sys.argv) == 3:
     match_bySCSIid = True
     SCSIid = sys.argv[1]
-if len(sys.argv) > 2:
     mpp_path_update = True
     mpp_entry = sys.argv[2]
 

--- a/drivers/mpathcount.py
+++ b/drivers/mpathcount.py
@@ -33,6 +33,7 @@ LOCK_NS2 = "mpathcount2"
 MP_INUSEDIR = "/dev/disk/mpInuse"
 mpp_path_update = False
 match_bySCSIid = False
+MPATHCOUNT_WAIT_INTERVAL = 2
 
 util.daemon()
 if len(sys.argv) == 3:
@@ -62,6 +63,8 @@ elif not mpathcountlock.acquireNoblock():
     mpathcountqueue.release()
 
 util.SMlog("MPATH: I get the lock")
+time.sleep(MPATHCOUNT_WAIT_INTERVAL)
+util.SMlog("MPATH: Time wait is done")
 
 cached_DM_maj = None
 def get_dm_major():

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -36,6 +36,7 @@ rm -rf $RPM_BUILD_ROOT
 [ ! -x /sbin/chkconfig ] || chkconfig --add sm-multipath
 service sm-multipath start
 %systemd_post make-dummy-sr.service
+%systemd_post mpcount.service
 %systemd_post snapwatchd.service
 %systemd_post updatempppathd.service
 
@@ -65,6 +66,7 @@ update-alternatives --install /etc/multipath.conf multipath.conf /etc/multipath.
 %preun
 [ ! -x /sbin/chkconfig ] || chkconfig --del sm-multipath
 %systemd_preun make-dummy-sr.service
+%systemd_preun mpcount.service
 %systemd_preun snapwatchd.service
 %systemd_preun updatempppathd.service
 #only remove in case of erase (but not at upgrade)
@@ -75,6 +77,7 @@ exit 0
 
 %postun
 %systemd_postun make-dummy-sr.service
+%systemd_postun mpcount.service
 %systemd_postun_with_restart snapwatchd.service
 %systemd_postun updatempppathd.service
 if [ $1 -eq 0 ]; then
@@ -89,6 +92,7 @@ fi
 %defattr(-,root,root,-)
 /etc/rc.d/init.d/mpathroot
 /etc/udev/scripts/xs-mpath-scsidev.sh
+/etc/udev/scripts/udevmpath.sh
 /etc/xapi.d/plugins/coalesce-leaf
 /etc/xapi.d/plugins/lvhd-thin
 /etc/xapi.d/plugins/nfs-on-slave
@@ -314,6 +318,7 @@ fi
 /sbin/mpathutil
 /etc/rc.d/init.d/sm-multipath
 %{_unitdir}/make-dummy-sr.service
+%{_unitdir}/mpcount.service
 %{_unitdir}/snapwatchd.service
 %{_unitdir}/updatempppathd.service
 %config /etc/udev/rules.d/40-multipath.rules

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -64,14 +64,14 @@ fi
 update-alternatives --install /etc/multipath.conf multipath.conf /etc/multipath.xenserver/multipath.conf 90
 
 %preun
-[ ! -x /sbin/chkconfig ] || chkconfig --del sm-multipath
 %systemd_preun make-dummy-sr.service
 %systemd_preun mpcount.service
 %systemd_preun snapwatchd.service
 %systemd_preun updatempppathd.service
 #only remove in case of erase (but not at upgrade)
 if [ $1 -eq 0 ] ; then
-	update-alternatives --remove multipath.conf /etc/multipath.xenserver/multipath.conf
+    [ ! -x /sbin/chkconfig ] || chkconfig --del sm-multipath
+    update-alternatives --remove multipath.conf /etc/multipath.xenserver/multipath.conf
 fi
 exit 0
 
@@ -87,6 +87,10 @@ if [ $1 -eq 0 ]; then
 elif [ $1 -eq 1 ]; then
     true; 
 fi
+
+%posttrans
+[ ! -x /sbin/chkconfig ] || chkconfig --add sm-multipath
+
 
 %files
 %defattr(-,root,root,-)

--- a/multipath/mpcount.service
+++ b/multipath/mpcount.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Multipath Count Service
+
+[Service]
+Type=forking
+ExecStart=/etc/udev/scripts/udevmpath.sh

--- a/scripts/udevmpath.sh
+++ b/scripts/udevmpath.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+echo /opt/xensource/sm/mpathcount.py | at now 2> /dev/null
+exit 0
+

--- a/udev/40-multipath.rules
+++ b/udev/40-multipath.rules
@@ -7,5 +7,5 @@ ACTION=="change", PROGRAM!="/sbin/dmsetup info -c --noheadings -j %M -m %m", GOT
 PROGRAM!="/sbin/dmsetup info -c -o uuid,name --separator ' ' --noheadings -j %M -m %m", GOTO="end_mpath"
 RESULT!="mpath-*", GOTO="end_mpath"
 # ENV is necessary otherwise the child process of mpathcount cannot find multipathd executable
-ACTION=="change", ENV{SCSIID}="%c{2}", ENV{PATH}="/sbin:/bin:/usr/sbin:/usr/bin", RUN+="/opt/xensource/sm/mpathcount.py $env{SCSIID}"
+ACTION=="change", RUN+="/usr/bin/systemctl --no-block start mpcount.service"
 LABEL="end_mpath"


### PR DESCRIPTION
This pr should supercede ps 336 since it is fixing some problems found with pr 336

Revert "CA-208229: enable mpathcount filtering by SCSIid"
CP-19247: Fix mpathcount problems affecting scalability test
CA-234893: sm-multipath.service goes inactive after SM RPM upgrade