### PR TITLE
CA-246343: prevent incorrect usage of getSCSIid

### DIFF
--- a/drivers/scsiutil.py
+++ b/drivers/scsiutil.py
@@ -99,11 +99,12 @@ def getSCSIid(path):
             util.CommandException
     """
 
-    try:
-        stdout = util.pread2([SCSI_ID_BIN, '-g', '--device', path])
-    except util.CommandException: # fallback call
-        dev = rawdev(path)
-        stdout = util.pread2([SCSI_ID_BIN, '-g', '-s', '/block/%s' % dev])
+    if not path.startswith('/dev/'):
+        util.SMlog("getSCSIid: fixing invalid input {}".format(path),
+                   priority=util.LOG_WARNING)
+        path = '/dev/' + path.lstrip('/')
+
+    stdout = util.pread2([SCSI_ID_BIN, '-g', '--device', path])
 
     return SCSIid_sanitise(stdout[:-1])
 


### PR DESCRIPTION
getSCSIid is called sometimes with only the device basename.
If this is the case, adding '/dev/' in front of the name
should rectify this.

Removed the fallback case (legacy of a transitional phase while
updagrading the user space stack) that was just creating
confusion.

Signed-off-by: Germano Percossi \<germano.percossi@citrix.com\>