### PR TITLE
CA-254408: Fix variable shadowing

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -869,8 +869,7 @@ class Tapdisk(object):
         self._set_dirty()
 
     def stats(self):
-        json = TapCtl.stats(self.pid, self.minor)
-        return json.loads(json)
+        return json.loads(TapCtl.stats(self.pid, self.minor))
 
     #
     # NB. dirty/refresh: reload attributes on next access


### PR DESCRIPTION
The binding of the intermediate variable shadowed the module name "json", this fixed it.

Signed-off-by: Zheng Li <zheng.li3@citrix.com>