### PR TITLE
Delete LUN on detach of RawISCSI

### DIFF
--- a/drivers/BaseISCSI.py
+++ b/drivers/BaseISCSI.py
@@ -408,7 +408,7 @@ class BaseISCSISR(SR.SR):
                 realdev = os.path.realpath("/dev/disk/by-scsid/%s/%s" % (self.dconf['SCSIid'], dev))
                 util.set_scheduler(realdev.split("/")[-1], "noop")
 
-    def detach(self, sr_uuid):
+    def detach(self, sr_uuid, delete=False):
         keys = []
         pbdref = None
         try:
@@ -438,6 +438,8 @@ class BaseISCSISR(SR.SR):
         if iscsilib._checkTGT(self.targetIQN):
             try:
                 iscsilib.logout(self.target, self.targetIQN, all=True)
+                if delete:
+                    iscsilib.delete(self.targetIQN)
             except util.CommandException, inst:
                     raise xs_errors.XenError('ISCSIQueryDaemon', \
                           opterr='error is %d' % inst.code)

--- a/drivers/RawISCSISR.py
+++ b/drivers/RawISCSISR.py
@@ -59,6 +59,9 @@ class RawISCSISR(BaseISCSI.BaseISCSISR):
         super(RawISCSISR, self).load(vdi_uuid)
         self.managed = True
 
+    def detach(self, sr_uuid):
+        super(RawISCSISR, self).detach(sr_uuid, True)
+
     def vdi(self, uuid):
         return ISCSIVDI(self, uuid)
 

--- a/drivers/XE_SR_ERRORCODES.xml
+++ b/drivers/XE_SR_ERRORCODES.xml
@@ -726,6 +726,11 @@
                 <description>Error in Metadata volume operation for SR.</description>
                 <value>181</value>
         </code>
+        <code>
+                <name>ISCSIDelete</name>
+                <description>ISCSI delete failed</description>
+                <value>182</value>
+        </code>
         <!-- Catch all error 200 (arbitrary) -->
         <code>
                 <name>EIO</name>

--- a/drivers/iscsilib.py
+++ b/drivers/iscsilib.py
@@ -303,6 +303,14 @@ def logout(portal, target, all=False):
     except:
         raise xs_errors.XenError('ISCSILogout')
 
+def delete(target):
+    cmd = ["iscsiadm", "-m", "node", "-o", "delete", "-T", target]
+    failuremessage = "Failed to delete target"
+    try:
+        (stdout,stderr) = exn_on_failure(cmd,failuremessage)
+    except:
+        raise xs_errors.XenError('ISCSIDelete')
+
 def get_luns(targetIQN, portal):
     refresh_luns(targetIQN, portal)
     luns=[]


### PR DESCRIPTION
iscsi: Delete LUN on detach of RawISCSI

We need to evict stale cached entry for LUN that's undergoing migration.

Signed-off-by: Rick Mesta <rick.mesta@rackspace.com>
Signed-off-by: Doug Goldstein <doug.goldstein@rackspace.com>
Reviewed-by: Doug Goldstein <doug.goldstein@rackspace.com>