### PR TITLE
CA-218867: Handle exceptions and fail more elegantly

### DIFF
--- a/drivers/SRCommand.py
+++ b/drivers/SRCommand.py
@@ -384,11 +384,12 @@ def run(driver, driver_info):
         except:
             pass
 
-        # If exception is of type SR.SRException,
-        # pass to xapi, else re-raise.
+        # If exception is of type SR.SRException, pass to Xapi.
+        # If generic python Exception, print a generic xmlrpclib
+        # dump and pass to XAPI.
         if isinstance(e, SR.SRException):
             print e.toxml()
         else:
-            raise
+            print xmlrpclib.dumps(xmlrpclib.Fault(1200, str(e)), "", True) 
 
     sys.exit(0)

--- a/drivers/XE_SR_ERRORCODES.xml
+++ b/drivers/XE_SR_ERRORCODES.xml
@@ -850,5 +850,11 @@
             <value>460</value>
         </code>
 
+        <code>
+            <name>GenericException</name>
+            <description>SM has thrown a generic python exception</description>
+            <value>1200</value>
+        </code>
+
 
 </SM-errorcodes>


### PR DESCRIPTION
Added a catch for generic Exceptions in SRCommand.run(driver, driver_info).
This prints a xmlrpclib dump containing the details of the generic exception,
in the same way SR.SRExeption.toxml() does. In this way all unexpected errors
should be caught and printed in a syntax Xapi understands. A new error code
(1200) has also been defined in XE_SR_ERRORCODES.xml to broadly categorise
generic errors. Some tests have also been changed and updated to test throwing
exceptions in a more appropriate manner.

Signed-off-by: James Davis <james.davis1@citrix.com>
Reviewed-by: Mark Syms <mark.syms@citrix.com>