### PR TITLE
Ignore multipath flag for blacklisted devices

### DIFF
--- a/drivers/XE_SR_ERRORCODES.xml
+++ b/drivers/XE_SR_ERRORCODES.xml
@@ -759,6 +759,11 @@
                 <value>430</value>
         </code>
         <code>
+                <name>MultipathGenericFailure</name>
+                <description>Multipath generic failure</description>
+                <value>431</value>
+        </code>
+        <code>
             <name>TapdiskAlreadyRunning</name>
             <description>The tapdisk is already running</description>
             <value>445</value>

--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -10,6 +10,7 @@ defaults {
 }
 blacklist {
 	devnode	"^nvme.*"
+	devnode "scini*"
 }
 # Leave this section in place even if empty
 blacklist_exceptions {

--- a/tests/test_mpath_dmp.py
+++ b/tests/test_mpath_dmp.py
@@ -1,0 +1,40 @@
+import mock
+import unittest
+import testlib
+import mpath_dmp
+import SR
+
+
+class Test_mpath_dmp(unittest.TestCase):
+
+    @testlib.with_context
+    @mock.patch('mpath_dmp.util', autospec=True)
+    def test_is_valid_multipath_device(self, context, util_mod):
+        """
+        Tests for checking validity of multipath device
+        """
+
+        # Setup errors codes
+        context.setup_error_codes()
+
+        # Test 'multipath -a' failure
+        util_mod.doexec.side_effect = [(1, "out", "err")]
+        self.assertFalse(mpath_dmp._is_valid_multipath_device("fake_dev"))
+
+        # Test 'multipath -c' with error and empty output
+        util_mod.doexec.side_effect = [(0, "out", "err"), (1, "", ""), OSError()]
+        with self.assertRaises(SR.SROSError) as exc:
+            mpath_dmp._is_valid_multipath_device("xx")
+        self.assertEqual(exc.exception.errno, 431)
+
+        # Test 'multipath -c' with error but some output
+        util_mod.doexec.side_effect = [(0, "out", "err"), (1, "xx", "")]
+        self.assertFalse(mpath_dmp._is_valid_multipath_device("fake_dev"))
+        util_mod.doexec.side_effect = [(0, "out", "err"), (1, "xx", "yy")]
+        self.assertFalse(mpath_dmp._is_valid_multipath_device("fake_dev"))
+        util_mod.doexec.side_effect = [(0, "out", "err"), (1, "", "yy")]
+        self.assertFalse(mpath_dmp._is_valid_multipath_device("fake_dev"))
+
+        # Test when everything is fine
+        util_mod.doexec.side_effect = [(0, "out", "err"), (0, "out", "err")]
+        self.assertTrue(mpath_dmp._is_valid_multipath_device("fake_dev"))


### PR DESCRIPTION
By design, when multipath is enabled on a host, the storage manager is
expecting to handle any valid block device used by an SR.

There are cases where the user wants to use multipath along with other
SRs using block devices incompatible with multipath.

This modification will let SM proceed without enforcing multipath if
multipath believes that device has been explicitly blacklisted