### PR TITLE
    CA-263084: Fix path to iSCSI database

### DIFF
--- a/drivers/iscsilib.py
+++ b/drivers/iscsilib.py
@@ -44,6 +44,9 @@ _REPLACEMENT_TMO_MPATH = 15
 _REPLACEMENT_TMO_DEFAULT = 144
 _REPLACEMENT_TMO_STANDARD = 120
 
+_ISCSI_DB_PATH = '/var/lib/iscsi'
+
+
 def exn_on_failure(cmd, message):
     '''Executes via util.doexec the command specified. If the return code is 
     non-zero, raises an ISCSIError with the given message'''
@@ -94,17 +97,21 @@ def parse_IP_port(portal):
         ipaddr = ipaddr[1:-1]
     return (ipaddr, port)
 
+
 def save_rootdisk_nodes():
     root_iqns = get_rootdisk_IQNs()
     if root_iqns:
-        srcdirs = map(lambda iqn: '/etc/iscsi/nodes/%s' % iqn, root_iqns)
-        util.doexec(['/bin/cp','-a'] + srcdirs + ['/tmp'])
+        srcdirs = map(lambda iqn: os.path.join(_ISCSI_DB_PATH, 'nodes', iqn),
+                      root_iqns)
+        util.doexec(['/bin/cp', '-a'] + srcdirs + ['/tmp'])
+
 
 def restore_rootdisk_nodes():
     root_iqns = get_rootdisk_IQNs()
     if root_iqns:
-        srcdirs = map(lambda iqn: '/tmp/%s' % iqn, root_iqns)
-        util.doexec(['/bin/cp','-a'] + srcdirs + ['/etc/iscsi/nodes/'])
+        srcdirs = map(lambda iqn: os.path.join('/tmp', iqn), root_iqns)
+        util.doexec(['/bin/cp', '-a'] + srcdirs +
+                    [os.path.join(_ISCSI_DB_PATH, 'nodes')])
 
 
 def discovery(target, port, chapuser, chappass, targetIQN="any",
@@ -325,13 +332,13 @@ def stop_daemon():
 
 def restart_daemon():
     stop_daemon()
-    if os.path.exists('/etc/iscsi/nodes'):
+    if os.path.exists(os.path.join(_ISCSI_DB_PATH, 'nodes')):
         try:
-            shutil.rmtree('/etc/iscsi/nodes')
+            shutil.rmtree(os.path.join(_ISCSI_DB_PATH, 'nodes'))
         except:
             pass
         try:
-            shutil.rmtree('/etc/iscsi/send_targets')
+            shutil.rmtree(os.path.join(_ISCSI_DB_PATH, 'send_targets'))
         except:
             pass
     if os.path.exists("/etc/init.d/open-iscsi"):

--- a/tests/test_iscsilib.py
+++ b/tests/test_iscsilib.py
@@ -1,0 +1,42 @@
+import iscsilib
+import mock
+import unittest
+
+
+class Test_iscsilib(unittest.TestCase):
+
+    @mock.patch('iscsilib.get_rootdisk_IQNs')
+    @mock.patch('util.doexec')
+    def test_save_rootdisk_nodes(self, doexec, get_rootdisk_iqns):
+        get_rootdisk_iqns.return_value = ['iqn.2003-01.com.bla:00.ecd28.mo121']
+
+        iscsilib.save_rootdisk_nodes()
+
+        doexec.assert_called_with(['/bin/cp', '-a',
+                                   '/var/lib/iscsi/nodes/iqn.2003-01.com.bla:'
+                                   '00.ecd28.mo121',
+                                   '/tmp'])
+
+    @mock.patch('iscsilib.get_rootdisk_IQNs')
+    @mock.patch('util.doexec')
+    def test_restore_rootdisk_nodes(self, doexec, get_rootdisk_iqns):
+        get_rootdisk_iqns.return_value = ['iqn.2003-01.com.bla:00.ecd28.mo121']
+
+        iscsilib.restore_rootdisk_nodes()
+
+        doexec.assert_called_with(['/bin/cp', '-a',
+                                   '/tmp/iqn.2003-01.com.bla:00.ecd28.mo121',
+                                   '/var/lib/iscsi/nodes'])
+
+    @mock.patch('iscsilib.stop_daemon', mock.Mock())
+    @mock.patch('iscsilib.exn_on_failure', mock.Mock())
+    @mock.patch('util.doexec', mock.Mock())
+    @mock.patch('os.path.exists')
+    @mock.patch('shutil.rmtree')
+    def test_restart_daemon(self, rmtree, exists):
+        exists.return_value = True
+
+        iscsilib.restart_daemon()
+
+        rmtree.assert_has_calls([mock.call('/var/lib/iscsi/nodes'),
+                                 mock.call('/var/lib/iscsi/send_targets')])


### PR DESCRIPTION
    The iSCSI database is located /var/lib/iscsi instead of /etc/iscsi in recent
    Linux distributions.

    This fix resolves the following problems:
    - On SCTX-2590 - the impact of this was that the connection using multiple
      "c_iface"-s was not established, as the default interface was already
      cached.

    Based on looking at the code, this fix may also help in the following
    scenarios
    - iSCSI boot from SAN may have been broken, as the iSCSI connection state
      for the root disk was not persisted across discoveries.
    - If a storage array changes IP addresses, it doesn't even get discovered
      after a reboot.

    This commit does not introduce an explicit warning or failure, as we're
    working on a replacement for this (Transport) code.

    Signed-off-by: Robert Breker <robert.breker@citrix.com>
    Reviewed-by: Germano Percossi <germano.percossi@citrix.com>