### PR TITLE
CA-264210: Intellicache only supports a single base disk with deltas.

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1844,6 +1844,11 @@ class VDI(object):
         parent_uuid = parent_uuid.strip()
         shared_target = NFSSR.NFSFileVDI(self.target.vdi.sr, parent_uuid)
 
+        if shared_target.parent:
+            util.SMlog("ERROR: Parent VDI %s has parent, not enabling" %
+                       shared_target.uuid)
+            return
+
         SR.registerSR(EXTSR.EXTSR)
         local_sr = SR.SR.from_uuid(session, local_sr_uuid)
 


### PR DESCRIPTION
If the parent of the VDI being activated also has a parent then exit.

Signed-off-by: Mark Syms <mark.syms@citrix.com>
Reviewed-by: Germano Percossi <germano.percossi@citrix.com>