### PR TITLE
CA-267032: add ESRCH to list of acceptable errors in pid search

### DIFF
--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1263,7 +1263,7 @@ def findRunningProcessOrOpenFile(name, process = True):
                     f = open(os.path.join('/proc', pid, 'cmdline'), 'rb')
                     prog = f.read()[:-1]
                 except IOError, e:
-                    if e.errno != errno.ENOENT:
+                    if e.errno in (errno.ENOENT, errno.ESRCH):
                         SMlog("ERROR %s reading %s, ignore" % (e.errno, pid))
                     continue
             finally:
@@ -1274,7 +1274,8 @@ def findRunningProcessOrOpenFile(name, process = True):
                 fd_dir = os.path.join('/proc', pid, 'fd')
                 files = os.listdir(fd_dir)
             except OSError, e:
-                if e.errno == errno.ENOENT:
+                if e.errno in (errno.ENOENT, errno.ESRCH):
+                    SMlog("ERROR %s reading fds for %s, ignore" % (e.errno, pid))
                     # Ignore pid that are no longer valid
                     continue
                 else:


### PR DESCRIPTION
Signed-off-by: Mark Syms <mark.syms@citrix.com>
Reviewed-by: Germano Percossi <germano.percossi@citrix.com>