### PR TITLE
Ca 274584

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,8 @@ install: precheck
 	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
 	install -m 644 snapwatchd/snapwatchd.service \
 	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
+	install -m 644 systemd/xs-sm.service \
+	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
 	for i in $(UDEV_RULES); do \
 	  install -m 644 udev/$$i.rules \
 	    $(SM_STAGING)$(UDEV_RULES_DIR); done

--- a/systemd/xs-sm.service
+++ b/systemd/xs-sm.service
@@ -9,7 +9,7 @@ Wants=iscsi-shutdown.service
 [Service]
 Type=oneshot
 RemainAfterExit=True
-ExecStart=-/bin/true
+ExecStart=-/usr/sbin/multipath -W
 ExecStop=-/bin/true
 
 [Install]

--- a/systemd/xs-sm.service
+++ b/systemd/xs-sm.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=XenServer Storage Manager (SM)
+Before=xapi.service
+Conflicts=shutdown.target
+RefuseManualStop=yes
+After=iscsi-shutdown.service
+Wants=iscsi-shutdown.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=True
+ExecStart=-/bin/true
+ExecStop=-/bin/true
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
CA-274584: Provide SM service to take care of reboot issues with iscsi  …
Upon reboot/shutdown Xapi does not call pbd-unplug to gracefully
detach the SRs.

In this specific case, iscsid has been started by SM and iscsi
sessions have been logged in by SM.
Under some circumstances, iscsid will refuse to shutdown because there
are some iscsi sessions on the system that have not been closed: SM
did not get any chance to do it.

This service introduces a dependency on iscsi-shutdown service.

In order for this to work, the spec file (or else) needs to contain
the code to enable this service.

This should fix CA-272842, too.

Signed-off-by: Germano Percossi <germano.percossi@citrix.com>
Reviewed-by: Mark Syms <mark.syms@citrix.com>

CA-276751: clean-up wwids at start-up  …
This is another issue due to the fact that Xapi does not unplug
the SRs upon reboot.

SM is responsible for the multipath wwids file but if not called
to detach the SRs it does not have the chance to clean it.

This addition to the service clean-up every wwid that is not in use
during reboot.

Because it is very unlikely that something is already in use during
reboot (apart from the root disk), this prevents users from adding
their own wwids to mark some devices as special.
However, this behavious is not discouraged anyway, because SM needs
to have full control over multipath.

Signed-off-by: Germano Percossi <germano.percossi@citrix.com>
Reviewed-by: Mark Syms <mark.syms@citrix.com>