### PR TITLE
Rationalise installation of pip packages as much as possible

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -1,0 +1,6 @@
+mock
+xenapi
+coverage
+astroid==1.4.9
+pylint==1.5
+bitarray

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,2 +1,2 @@
+nose
 -r base_requirements.txt
-coveralls

--- a/tests/run_python_unittests.sh
+++ b/tests/run_python_unittests.sh
@@ -4,7 +4,7 @@ set -eu
 
 SMROOT=$(cd $(dirname $0) && cd .. && pwd)
 
-if  [ ! -x "$(command -v nosetests)" ] || [ ! -x "$(command -v coverage)" ]; then
+if  [ ! -v RPM_BUILD_ROOT ]; then
     echo "Activating virtual env"
 
     ENVDIR="$SMROOT/.env"

--- a/tests/setup_env_for_python_unittests.sh
+++ b/tests/setup_env_for_python_unittests.sh
@@ -15,7 +15,6 @@ pip install six
 pip install packaging
 pip install appdirs
 pip install --upgrade setuptools
-pip install nose
-pip install coverage
-pip install mock==1.0.1
-pip install bitarray
+pip install -r $SMROOT/dev_requirements.txt
+
+


### PR DESCRIPTION
Ensure that unit tests use virtualenv when not in RPM build.

Signed-off-by: Mark Syms <mark.syms@citrix.com>
Reviewed-by: Chandrika Srinivasan <chandrika.srinivasan@citrix.com>