### PR TITLE
CA-273731: call _testHost before trying to mount ISO SR NFS share

### DIFF
--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -46,6 +46,7 @@ DRIVER_INFO = {
 TYPE = "iso"
 SMB_VERSION_1 = '1.0'
 SMB_VERSION_3 = '3.0'
+NFSPORT = 2049
 
 def is_image_utf8_compatible(s):
     regex = re.compile("\.iso$|\.img$", re.I)
@@ -314,6 +315,7 @@ class ISOSR(SR.SR):
                 # going to be r-only, a failure in nfs link can be reported back
                 # to the process waiting.
                 serv_path = location.split(':')
+                util._testHost(serv_path[0], NFSPORT, 'NFSTarget')
                 nfs.soft_mount(self.mountpoint, serv_path[0], serv_path[1],
                                'tcp', useroptions=options,
                                nfsversion=self.nfsversion)

--- a/tests/test_ISOSR.py
+++ b/tests/test_ISOSR.py
@@ -69,10 +69,11 @@ class TestISOSR_overNFS(unittest.TestCase):
     @mock.patch('util._convertDNS', autospec=True)
     @mock.patch('nfs.validate_nfsversion', autospec=True)
     @mock.patch('util.makedirs', autospec=True)
+    @mock.patch('util._testHost', autospec=True)
     # Can't use autospec due to http://bugs.python.org/issue17826
     @mock.patch('ISOSR.ISOSR._checkmount')
-    def test_attach_nfs(self, _checkmount, makedirs, validate_nfsversion,
-                        convertDNS, soft_mount, gen_uuid):
+    def test_attach_nfs(self, _checkmount, testHost, makedirs,
+                        validate_nfsversion, convertDNS, soft_mount, gen_uuid):
         validate_nfsversion.return_value = 'aNfsversionChanged'
         isosr = self.create_isosr(location='aServer:/aLocation', atype='nfs_iso',
                                   sr_uuid='asr_uuid')
@@ -87,6 +88,29 @@ class TestISOSR_overNFS(unittest.TestCase):
                                            'tcp',
                                            useroptions='',
                                            nfsversion='aNfsversionChanged')
+
+    @mock.patch('util.gen_uuid', autospec=True)
+    @mock.patch('util._convertDNS', autospec=True)
+    @mock.patch('nfs.validate_nfsversion', autospec=True)
+    @mock.patch('util.makedirs', autospec=True)
+    @mock.patch('util._testHost', autospec=True)
+    # Can't use autospec due to http://bugs.python.org/issue17826
+    @mock.patch('ISOSR.ISOSR._checkmount')
+    def test_attach_nfs_no_server(
+            self, _checkmount, testHost, makedirs, validate_nfsversion,
+            convertDNS, gen_uuid):
+
+        isosr = self.create_isosr(location='aServer:/aLocation', atype='nfs_iso',
+                                  sr_uuid='asr_uuid')
+
+        _checkmount.side_effect = [False]
+        testHost.side_effect = SR.SROSError(140, 'Incorrect DNS name, unable to resolve.')
+
+        with self.assertRaises(SR.SROSError) as ose:
+            isosr.attach(None)
+
+        self.assertEqual(140, ose.exception.errno)
+
 
 class TestISOSR_overSMB(unittest.TestCase):
 


### PR DESCRIPTION
Signed-off-by: Mark Syms <mark.syms@citrix.com>
Reviewed-by: Chandrika Srinivasan <chandrika.srinivasan@citrix.com>