### PR TITLE
CA-290491: do not leaf coalesce caching VDIs

### DIFF
--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -414,6 +414,7 @@ class VDI:
     DB_VDI_TYPE = "vdi_type"
     DB_VHD_BLOCKS = "vhd-blocks"
     DB_VDI_PAUSED = "paused"
+    DB_CACHING = "caching"
     DB_GC = "gc"
     DB_COALESCE = "coalesce"
     DB_LEAFCLSC = "leaf-coalesce" # config key
@@ -431,6 +432,7 @@ class VDI:
             DB_VDI_TYPE:     XAPI.CONFIG_SM,
             DB_VHD_BLOCKS:   XAPI.CONFIG_SM,
             DB_VDI_PAUSED:   XAPI.CONFIG_SM,
+            DB_CACHING:      XAPI.CONFIG_SM,
             DB_GC:           XAPI.CONFIG_OTHER,
             DB_COALESCE:     XAPI.CONFIG_OTHER,
             DB_LEAFCLSC:     XAPI.CONFIG_OTHER,
@@ -1500,6 +1502,9 @@ class SR:
                 continue
             if vdi.getConfig(vdi.DB_ONBOOT) == vdi.ONBOOT_RESET:
                 Util.log("Skipping reset-on-boot %s" % vdi)
+                continue
+            if vdi.getConfig(vdi.DB_CACHING) == "true":
+                Util.log("Skipping caching %s" % vdi)
                 continue
             if vdi.getConfig(vdi.DB_LEAFCLSC) == vdi.LEAFCLSC_DISABLED:
                 Util.log("Leaf-coalesce disabled for %s" % vdi)


### PR DESCRIPTION
There is some bad interactions between caching VDIs (currently attached)
and SMGC's leaf coalescing process (which didn't take that into consideration).

This wasn't an issue before the change of CP-18840, when the leaf coalescing
was completely disabled on file-based SR.

This change still allows leaf coalescing on file-based SR as CP-18840, but just
avoids online leaf coalescing any caching VDIs. There is very little benefit to
do this (for file-based SRs), and offline coalscing these nodes is still possible
as soon as these VDIs become detached.

Signed-off-by: Zheng Li <zheng.li3@citrix.com>