### PR TITLE
CA-292103: do not scan for and clear signatures in new volumes

### DIFF
--- a/drivers/lvutil.py
+++ b/drivers/lvutil.py
@@ -507,6 +507,8 @@ def create(name, size, vgname, tag=None, size_in_percentage=None):
         cmd = [CMD_LVCREATE, "-n", name, "-L", str(size_mb), vgname]
     if tag:
         cmd.extend(["--addtag", tag])
+
+    cmd.extend(['-W', 'n'])
     cmd_lvm(cmd)
 
 def remove(path, config_param=None):

--- a/tests/lvmlib.py
+++ b/tests/lvmlib.py
@@ -71,6 +71,7 @@ class LVSubsystem(object):
         parser.add_option("--addtag", dest='tag')
         parser.add_option("--inactive", dest='inactive', action='store_true')
         parser.add_option("--zero", dest='zero', default='y')
+        parser.add_option("-W", dest='wipe_sig')
         try:
             options, args = parser.parse_args(args[1:])
         except SystemExit, e:

--- a/tests/test_lvutil.py
+++ b/tests/test_lvutil.py
@@ -84,10 +84,8 @@ class TestCreate(unittest.TestCase):
         lvutil.create('volume', ONE_MEGABYTE, 'VG_XenStorage-b3b18d06-b2ba-5b67-f098-3cdd5087a2a7',
                       size_in_percentage="10%F")
 
-        mock_pread.assert_called_once_with(
-            [os.path.join(lvutil.LVM_BIN,lvutil.CMD_LVCREATE)] +
-            "-n volume -l 10%F VG_XenStorage-b3b18d06-b2ba-5b67-f098-3cdd5087a2a7".split(),
-            quiet=False)
+        self.assertEqual(1, mock_pread.call_count)
+        self.assertIn("10%F", mock_pread.call_args[0][0])
 
 class TestRemove(unittest.TestCase):
     @with_lvm_subsystem


### PR DESCRIPTION
From SCTX-2673, rare occurence where the new LV could contain data
which causes a segfault in libblkid when scanning for signatures.
Which isn't required anyway as the next step is to apply a VHD image
format onto the volume.

Signed-off-by: Mark Syms <mark.syms@citrix.com>