### PR TITLE
CA-295861: extract processname correctly when there are no arguments

### DIFF
--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1271,7 +1271,8 @@ def findRunningProcessOrOpenFile(name, process = True):
                     prog = f.read()[:-1]
                     if prog:
                         # Just want the process name
-                        prog =  prog[:prog.find('\x00')]
+                        argv = prog.split('\x00')
+                        prog =  argv[0]
                 except IOError, e:
                     if e.errno in (errno.ENOENT, errno.ESRCH):
                         SMlog("ERROR %s reading %s, ignore" % (e.errno, pid))


### PR DESCRIPTION
Signed-off-by: Mark Syms <mark.syms@citrix.com>