### PR TITLE
CA-295775 Fix handling of multipath events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,6 @@ install: precheck
 	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
 	install -m 644 etc/make-dummy-sr.service \
 	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
-	install -m 644 multipath/mpcount.service \
-	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
 	install -m 644 snapwatchd/snapwatchd.service \
 	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
 	install -m 644 systemd/xs-sm.service \
@@ -209,7 +207,7 @@ install: precheck
 	ln -sf $(SM_DEST)lcache.py $(SM_STAGING)$(BIN_DEST)tapdisk-cache-stats
 	ln -sf /dev/null $(SM_STAGING)$(UDEV_RULES_DIR)/69-dm-lvm-metad.rules
 	install -m 755 scripts/xs-mpath-scsidev.sh $(SM_STAGING)$(UDEV_SCRIPTS_DIR)
-	install -m 755 scripts/udevmpath.sh $(SM_STAGING)$(UDEV_SCRIPTS_DIR)
+	install -m 755 scripts/onequeue.sh $(SM_STAGING)$(UDEV_SCRIPTS_DIR)
 	install -m 755 scripts/xe-get-arrayid-lunnum $(SM_STAGING)$(BIN_DEST)
 	install -m 755 scripts/xe-getarrayidentifier $(SM_STAGING)$(BIN_DEST)
 	install -m 755 scripts/xe-getlunidentifier $(SM_STAGING)$(BIN_DEST)

--- a/drivers/mpath_cli.py
+++ b/drivers/mpath_cli.py
@@ -29,7 +29,7 @@ class MPathCLIFail(exceptions.Exception):
 	def __str__(self):
 		print "","MPath CLI failed"
 
-mpathcmd = ["multipathd","-k"]
+mpathcmd = ["/usr/sbin/multipathd","-k"]
 
 def mpexec(cmd):
     util.SMlog("mpath cmd: %s" % cmd)

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -36,7 +36,6 @@ rm -rf $RPM_BUILD_ROOT
 [ ! -x /sbin/chkconfig ] || chkconfig --add sm-multipath
 service sm-multipath start
 %systemd_post make-dummy-sr.service
-%systemd_post mpcount.service
 %systemd_post snapwatchd.service
 %systemd_post updatempppathd.service
 
@@ -65,7 +64,6 @@ update-alternatives --install /etc/multipath.conf multipath.conf /etc/multipath.
 
 %preun
 %systemd_preun make-dummy-sr.service
-%systemd_preun mpcount.service
 %systemd_preun snapwatchd.service
 %systemd_preun updatempppathd.service
 #only remove in case of erase (but not at upgrade)
@@ -77,7 +75,6 @@ exit 0
 
 %postun
 %systemd_postun make-dummy-sr.service
-%systemd_postun mpcount.service
 %systemd_postun_with_restart snapwatchd.service
 %systemd_postun updatempppathd.service
 if [ $1 -eq 0 ]; then
@@ -99,7 +96,7 @@ tests/run_python_unittests.sh
 %defattr(-,root,root,-)
 /etc/rc.d/init.d/mpathroot
 /etc/udev/scripts/xs-mpath-scsidev.sh
-/etc/udev/scripts/udevmpath.sh
+/etc/udev/scripts/onequeue.sh
 /etc/xapi.d/plugins/coalesce-leaf
 /etc/xapi.d/plugins/lvhd-thin
 /etc/xapi.d/plugins/nfs-on-slave
@@ -331,7 +328,6 @@ tests/run_python_unittests.sh
 /sbin/mpathutil
 /etc/rc.d/init.d/sm-multipath
 %{_unitdir}/make-dummy-sr.service
-%{_unitdir}/mpcount.service
 %{_unitdir}/snapwatchd.service
 %{_unitdir}/updatempppathd.service
 %config /etc/udev/rules.d/40-multipath.rules

--- a/multipath/mpcount.service
+++ b/multipath/mpcount.service
@@ -1,6 +1,0 @@
-[Unit]
-Description=Multipath Count Service
-
-[Service]
-Type=forking
-ExecStart=/etc/udev/scripts/udevmpath.sh

--- a/scripts/onequeue.sh
+++ b/scripts/onequeue.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/bash
+exec </dev/null &>/dev/null
+
+## This is a script more general than just SM and may eventually want
+## to move to another package. Its purpose is to help with running
+## a process to act on some event while other events may be arriving.
+##
+## Invoke as
+##
+## /etc/udev/scripts/onequeue.sh <lockname> <command> [args...]
+##
+## The first argument is a name for a lock (not a pathname, just a name).
+## This will be used for a wait lock (LOCK.wait) and a run lock (LOCK.run).
+## The remaining arguments are the command to run and arguments for that
+## command. Every different command/args set which might need to run
+## separately will need its own unique <lockname>
+##
+## onequeue will use the locks to ensure that there is never more than
+## one instance of <command> running, plus one instance waiting to run,
+## thus rate-limiting the running of <command> in the face of a storm of
+## events.
+##
+## It will further ensure that at least one instance of <command> will be
+## run following any given invocation via this mechanism, ensuring that
+## (for example in the case of a command which scans for changes), there
+## is never a change which gets lost.
+
+## Make somewhere to keep our lockfiles.
+LOCKDIR=/run/lock/onequeue
+/usr/bin/mkdir -p $LOCKDIR
+if [ $? -ne 0 ]; then
+    /usr/bin/logger -t onequeue -p daemon.notice "ERROR: Failed to create /run/lock/onequeue"
+fi
+
+## Get the name for the lock to use
+LOCK="$1"; shift
+## Get the remaining arguments as the program to run and its arguments
+PROGARGS="$*"
+
+runprog() {
+    (
+        /usr/bin/logger -t onequeue -p daemon.notice "'$PROGARGS' waiting to run"
+        ## Acquire an exclusive lock on fd 10 (LOCK.run). Wait as long as necessary
+        /usr/bin/flock -x 10
+        if [ $? -ne 0 ]; then
+            /usr/bin/logger -t onequeue -p daemon.notice "WARNING: '$PROGARGS' Failed to acquire $LOCK.run"
+            exit 1
+        fi
+        ## Now we have the run lock, drop the wait lock. Note this happens before
+        ## we invoke the handler command, which means a new waiter can queue from this
+        ## point, ensuring we never miss anything.
+        /usr/bin/flock -u 9
+        /usr/bin/logger -t onequeue -p daemon.notice "'$PROGARGS' running"
+        ## Invoke the handler command
+        $PROGARGS
+        /usr/bin/logger -t onequeue -p daemon.notice "'$PROGARGS' done"
+    ) 10>"$LOCKDIR/$LOCK.run"
+}
+
+(
+	## Attempt to acquire an exclusive lock on fd 9 (LOCK.wait)
+    /usr/bin/flock -x -n 9
+    if [ $? -ne 0 ]; then
+        ## If we didn't get it, someone is already waiting, so just exit.
+        /usr/bin/logger -t onequeue -p daemon.notice "'$PROGARGS' already queued on $LOCK; skipping."
+        exit 0
+    fi
+    ## Start the wait for LOCK.run in the background.
+    runprog &
+) 9>"$LOCKDIR/$LOCK.wait"
+

--- a/scripts/udevmpath.sh
+++ b/scripts/udevmpath.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-echo /opt/xensource/sm/mpathcount.py | at now 2> /dev/null
-exit 0
-

--- a/udev/40-multipath.rules
+++ b/udev/40-multipath.rules
@@ -7,5 +7,5 @@ ACTION=="change", PROGRAM!="/sbin/dmsetup info -c --noheadings -j %M -m %m", GOT
 PROGRAM!="/sbin/dmsetup info -c -o uuid,name --separator ' ' --noheadings -j %M -m %m", GOTO="end_mpath"
 RESULT!="mpath-*", GOTO="end_mpath"
 # ENV is necessary otherwise the child process of mpathcount cannot find multipathd executable
-ACTION=="change", RUN+="/usr/bin/systemctl --no-block start mpcount.service"
+ACTION=="change", RUN+="/etc/udev/scripts/onequeue.sh mpathcount /opt/xensource/sm/mpathcount.py"
 LABEL="end_mpath"


### PR DESCRIPTION
Sending multipath UDEV events via a systemd service into atd does not
work very well at getting them processed; systemd drops attempts to
start any service which is already in the process of starting (which
loses information in the case of an event storm) while atd is a batch
processor designed to do things "at some vague time in the future which
could turn out to be never if the system load is higher than some
number".

A better solution is to use neither, and when we are scanning for
updates because of a UDEV event, use a simple wait/run lock pair to
rate-limit scans while ensuring that every event is followed by a scan
as soon as possible so its new state is detected.

We can now remove the 2 second sleep in drivers/mpathcount.py

In addition, the match_pathup function in drivers/mpathcount.py was not
matching the 'faulty' status in the multipath output and thus was not
updating the status when it changed. (Cosmetic: removed a tab from a log
line, log why the db update failed if it did fail).

In drivers/mpath_cli.py invoke multipathd by its full path because we
know it. Do not rely on PATH search for things like this; udev does
not supply the PATH we want and we should avoid requiring it.