### PR TITLE
CA-299722 Adjust timeout and retrans NFS mount options

### DIFF
--- a/drivers/NFSSR.py
+++ b/drivers/NFSSR.py
@@ -146,7 +146,7 @@ class NFSSR(FileSR.FileSR):
         self.attached = True
 
 
-    def mount_remotepath(self, sr_uuid, timeout=100, retrans=12):
+    def mount_remotepath(self, sr_uuid, timeout=5, retrans=5):
         if not self._checkmount():
             # FIXME: What is the purpose of this check_server?
             # It doesn't stop us from continuing if the server

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1536,6 +1536,8 @@ class VDI(object):
         sr_other_config = self._session.xenapi.SR.get_other_config(sr_ref)
         timeout = nfs.get_nfs_timeout(sr_other_config)
         if timeout:
+            # Note NFS timeout values are in deciseconds
+            timeout = int((timeout+5) / 10)
             options["timeout"] = timeout + self.TAPDISK_TIMEOUT_MARGIN
         for i in range(self.ATTACH_DETACH_RETRY_SECS):
             try:

--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -120,7 +120,8 @@ def soft_mount(mountpoint, remoteserver, remotepath, transport, useroptions='',
                timeout=None, nfsversion=DEFAULT_NFSVERSION, retrans=None):
     """Mount the remote NFS export at 'mountpoint'.
 
-    The 'timeout' param here is in seconds
+    The 'timeout' param here is in deciseconds (tenths of a second). See
+    nfs(5) for details.
     """
     try:
         if not util.ioretry(lambda: util.isdir(mountpoint)):
@@ -149,7 +150,7 @@ def soft_mount(mountpoint, remoteserver, remotepath, transport, useroptions='',
     options += ',acdirmin=0,acdirmax=0'
 
     if timeout != None:
-        options += ",timeo=%s" % (timeout * 10)
+        options += ",timeo=%s" % timeout
     if retrans != None:
         options += ",retrans=%s" % retrans
     if useroptions != '':
@@ -269,7 +270,7 @@ def get_supported_nfs_versions(server):
                            (server))
 
 def get_nfs_timeout(other_config):
-    nfs_timeout = 10
+    nfs_timeout = 5
 
     if other_config.has_key('nfs-timeout'):
         val = int(other_config['nfs-timeout'])
@@ -281,7 +282,7 @@ def get_nfs_timeout(other_config):
     return nfs_timeout
 
 def get_nfs_retrans(other_config):
-    nfs_retrans = 12
+    nfs_retrans = 5
 
     if other_config.has_key('nfs-retrans'):
         val = int(other_config['nfs-retrans']) 

--- a/tests/test_NFSSR.py
+++ b/tests/test_NFSSR.py
@@ -86,6 +86,6 @@ class TestNFSSR(unittest.TestCase):
                                            '/aServerpath/UUID',
                                            'tcp',
                                            useroptions='options',
-                                           timeout=10,
+                                           timeout=5,
                                            nfsversion='aNfsversionChanged',
-                                           retrans=12)
+                                           retrans=5)


### PR DESCRIPTION
Keep the NFS timeo mount option in deciseconds always. Various parts of
the code appear to have tried to have it in seconds, except for one
place which apparently thought it was in centiseconds. This
inconsistency resulted in a timeout/retrans combination of 1000
deciseconds and 12 retries, which would mean it would take over 1.5
hours for an NFS operation to fail. This hides failures in the NFS
layer.

Adjust everywhere know that the timeo value is in deciseconds. Also,
since tapdisk will retry EIO, it makes sense to make the retry period
shorter and not to try so many times, so lower the defaults.