### PR TITLE
CA-294319: Do not create PV on first device

### DIFF
--- a/drivers/lvutil.py
+++ b/drivers/lvutil.py
@@ -440,15 +440,16 @@ def createVG(root, vgname):
                 raise xs_errors.XenError('LVMWrite', \
                       opterr='device %s' % dev)
 
-        try:
-            cmd_lvm([CMD_PVCREATE, "-ff", "-y", "--metadatasize", "10M", dev])
-        except util.CommandException, inst:
-            raise xs_errors.XenError('LVMPartCreate',
-                                     opterr='error is %d' % inst.code)
+        if not (dev == rootdev):
+            try:
+                cmd_lvm([CMD_PVCREATE, "-ff", "-y", "--metadatasize", "10M", dev])
+            except util.CommandException, inst:
+                raise xs_errors.XenError('LVMPartCreate',
+                                         opterr='error is %d' % inst.code)
 
     # Create VG on first device
     try:
-        cmd_lvm([CMD_VGCREATE, vgname, rootdev])
+        cmd_lvm([CMD_VGCREATE, "--metadatasize", "10M", vgname, rootdev])
     except :
         raise xs_errors.XenError('LVMGroupCreate')
 


### PR DESCRIPTION
In the upstream lvm2 (v2_02_177), it handles duplicate PVs differently
with currently used lvm2(v2_02_130) in XenSever. It will prefer first PV
but before it will choose last PV it sees. For example:
    root@xrtuk-13-09 ~]# ll /dev/disk/by-id/scsi-3600a098038303973743f486833396d42
    lrwxrwxrwx 1 root root 10 Aug 27 08:51 /dev/disk/by-id/scsi-3600a098038303973743f486833396d42 -> ../../sdak
From the log:
    SM: [12939]   WARNING: PV Iyrwu7-JpT6-l8dX-9K8x-Rz2z-n9hV-SUzMf9 on /dev/sdak was already found on /dev/sdd

So it the device will excluded by a filter internally.

There may be two options we can try to fix this issu:
    1: Patch upstream lvm2 to let it use last seen PV, but from the
    trend of upstream, it will prefer to use first seen PV and lots of
    code related with change. So it will need lots of effort to do this
    patch.
    2: When we creat VG, from current code logic, it will firstly create
    PV for each device and then create a VG for the first device, at
    last add other PVs to the VG. So we can skip first device to create
    PV as VG create will initialize the PV by using function "pvcreate_each_device".

Signed-off-by: Taoyong Ding <taoyong.ding@citrix.com>