### PR TITLE
CA-297628: Tweak mpath_dmp.py for using device-mapper-multipath-0.4.9…

### DIFF
--- a/drivers/mpath_dmp.py
+++ b/drivers/mpath_dmp.py
@@ -214,7 +214,7 @@ def _is_valid_multipath_device(sid):
     (ret, stdout, stderr) = util.doexec(['/usr/sbin/multipath', '-ll', sid])
     if not stdout+stderr:
         (ret, stdout, stderr) = util.doexec(['/usr/sbin/multipath', '-a', sid])
-        if ret == 1:
+        if ret < 0:
             util.SMlog("Failed to add {}: wwid could be explicitly "
                        "blacklisted\n Continue with multipath disabled for "
                        "this SR".format(sid))


### PR DESCRIPTION
…-119

Upstream patch '0135-RHBZ-1299600-path-dev-uevents.patch' changed
return value of function 'remember_wwid'.

Tweak calling code accordingly as we are using this return value
as an error indicator.

Signed-off-by: Liang Dai <liang.dai1@citrix.com>