### PR TITLE
CA-286144: add usb-scan systemd units

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,8 @@ install: precheck
 	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
 	install -m 644 systemd/xs-sm.service \
 	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
+	install -m 644 systemd/usb-scan.* \
+	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
 	for i in $(UDEV_RULES); do \
 	  install -m 644 udev/$$i.rules \
 	    $(SM_STAGING)$(UDEV_RULES_DIR); done

--- a/scripts/usb_change
+++ b/scripts/usb_change
@@ -17,5 +17,5 @@
 #
 # called by UDEV rule to trigger pusb scan, when USB device change is detected
 
-. /etc/xensource-inventory
-xe pusb-scan host-uuid=${INSTALLATION_UUID}
+# wake up usb-scan.service waiting on the pipe
+dd if=/dev/zero of=/var/run/usb-scan.sock bs=8 count=1 status=none conv=notrunc,noerror oflag=nonblock

--- a/systemd/usb-scan.service
+++ b/systemd/usb-scan.service
@@ -1,0 +1,7 @@
+Unit]
+Description=USB device scanner
+
+[Service]
+StandardInput=socket
+ExecStart=/usr/bin/sh -c '. /etc/xensource-inventory; while dd of=/dev/null bs=4096 count=1 status=none conv=noerror; do xe pusb-scan host-uuid=$${INSTALLATION_UUID}; done'
+Restart=always

--- a/systemd/usb-scan.socket
+++ b/systemd/usb-scan.socket
@@ -1,0 +1,9 @@
+[Unit]
+Before=systemd-udevd
+
+[Socket]
+ListenFIFO=/var/run/usb-scan.sock
+PipeSize=4096
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
udev does not tolerate the time it can take for XAPI to complete a
pUSB rescan request. Use a service listening on a socket to perform
the scan request so that the udev action just becomes writing to a
non-blocking pipe.