### PR TITLE
CA-302514 increase default NFS timeouts

### DIFF
--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -270,7 +270,7 @@ def get_supported_nfs_versions(server):
                            (server))
 
 def get_nfs_timeout(other_config):
-    nfs_timeout = 5
+    nfs_timeout = 100
 
     if other_config.has_key('nfs-timeout'):
         val = int(other_config['nfs-timeout'])
@@ -282,7 +282,7 @@ def get_nfs_timeout(other_config):
     return nfs_timeout
 
 def get_nfs_retrans(other_config):
-    nfs_retrans = 5
+    nfs_retrans = 3
 
     if other_config.has_key('nfs-retrans'):
         val = int(other_config['nfs-retrans']) 

--- a/tests/test_NFSSR.py
+++ b/tests/test_NFSSR.py
@@ -86,6 +86,6 @@ class TestNFSSR(unittest.TestCase):
                                            '/aServerpath/UUID',
                                            'tcp',
                                            useroptions='options',
-                                           timeout=5,
+                                           timeout=100,
                                            nfsversion='aNfsversionChanged',
-                                           retrans=5)
+                                           retrans=3)


### PR DESCRIPTION
5 deciseconds and 5 retransmissions is too short for the default NFS
timeouts. Increase this to 100 deciseconds and 3 retransmissions. This
is sized so we we will get EIO after 100 seconds which is intended to
provide an indication that NFS is in trouble before we get a timeout
from other parts of the system.