### PR TITLE
CA-298641: be more benign on removing host tag

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1472,9 +1472,11 @@ class VDI(object):
         host_ref = self._session.xenapi.host.get_by_uuid(util.get_this_host())
         sm_config = self._session.xenapi.VDI.get_sm_config(vdi_ref)
         host_key = "host_%s" % host_ref
-        assert sm_config.has_key(host_key)
-        self._session.xenapi.VDI.remove_from_sm_config(vdi_ref, host_key)
-        util.SMlog("Removed host key %s for %s" % (host_key, vdi_uuid))
+        if sm_config.has_key(host_key):
+            self._session.xenapi.VDI.remove_from_sm_config(vdi_ref, host_key)
+            util.SMlog("Removed host key %s for %s" % (host_key, vdi_uuid))
+        else:
+            util.SMlog("_remove_tag: host key %s not found, ignore" % host_key)
 
     def _get_pool_config(self, pool_name):
         pool_info = dict()


### PR DESCRIPTION
There are two reasons for this change:

  - For some cases, there can be no host tags present. E.g. on directly attached
    HA statfile, or some accidental failure when adding the tags.

  - remove_tags is called at the end of VDI detach, which is to cease, rather
    than to start, destructive operations. Even if the host tag is not present
    for some reason, simply ignoring this and going ahead won't make the
    situation worse. If there was damage, it was done already (at the time of
    attching and onwards). Simply aborting at this point will probably make
    things messier.

Signed-off-by: Zheng Li <zheng.li3@citrix.com>