### PR TITLE
CA-273708: improve VHD scan for file-based SR

### DIFF
--- a/drivers/FileSR.py
+++ b/drivers/FileSR.py
@@ -24,6 +24,7 @@ import xs_errors
 import cleanup
 import blktap2
 import time
+import glob
 from lock import Lock
 import xmlrpclib
 from constants import CBTLOG_TAG
@@ -257,6 +258,13 @@ class FileSR(SR.SR):
         except util.CommandException, inst:
             raise xs_errors.XenError('SRScan', opterr="error VHD-scanning " \
                     "path %s (%s)" % (self.path, inst))
+        try:
+            list_vhds = [FileVDI.extractUuid(v) for v in util.ioretry(lambda: glob.glob(pattern))]
+            if len(self.vhds) != len(list_vhds):
+                util.SMlog("VHD scan returns %d VHDs: %s" % (len(self.vhds), sorted(list(self.vhds))))
+                util.SMlog("VHD list returns %d VHDs: %s" % (len(list_vhds), sorted(list_vhds)))
+        except:
+            pass
         for uuid in self.vhds.iterkeys():
             if self.vhds[uuid].error:
                 raise xs_errors.XenError('SRScan', opterr='uuid=%s' % uuid)


### PR DESCRIPTION
The current "vhd-util scan" command makes use of the "-c" (NOFAIL) flag, so
that if it has difficulties scanning a particular VHD image file, it will
simply skip it, and the command always returns success. In a stressed
environment (e.g. CPU high load or poor connection to the storage), it might
return a partial list without giving any warnings.

With this change, we try without the NOFAIL flag first. If it fails, we
continue trying (ioretry). If it continues to fail, we'll log the result and
then go with the NOFAIL flag as the last resort, which should always succeed
(as before), but we'll additionally log its output in this case.

In addition, we improve logging in two places. If a line from the output of
"vhd-util scan" fails to parse, we'll log the line instead of ignoring it. For
file-based SR, we'll cross check the number of VHDs in the result of "vhd-util
scan" against the result from plain file globbing, and we'll log the difference
if any.

Signed-off-by: Zheng Li <zheng.li3@citrix.com>