### PR TITLE
CA-312608: Set scheduler to noop for tdX devices

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -817,8 +817,10 @@ class Tapdisk(object):
                 try:
                     TapCtl.open(pid, minor, _type, path, options)
                     try:
-                        return cls.__from_blktap(blktap)
-
+                        tapdisk = cls.__from_blktap(blktap)
+                        node = '/sys/dev/block/%d:%d' % (tapdisk.major(), tapdisk.minor)
+                        util.set_scheduler_sysfs_node(node, 'noop')
+                        return tapdisk
                     except:
                         TapCtl.close(pid, minor)
                         raise

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -977,6 +977,22 @@ def dom0_disks():
     SMlog("Dom0 disks: %s" % disks)
     return disks
 
+def set_scheduler_sysfs_node(node, str):
+    """Set the scheduler for a sysfs node (e.g. '/sys/block/sda')"""
+
+    path = os.path.join(node, "queue", "scheduler")
+    if not os.path.exists(path):
+        SMlog("no path %s" % path)
+        return
+    try:
+        f = open(path, 'w')
+        f.write("%s\n" % str)
+        f.close()
+        SMlog("Set scheduler to [%s] on [%s]" % (str, node))
+    except:
+        SMlog("Error setting scheduler to [%s] on [%s]" % (str, node))
+        pass
+
 def set_scheduler(dev, str):
     devices = []
     if not scsiutil.match_dm(dev):
@@ -987,18 +1003,7 @@ def set_scheduler(dev, str):
         devices = map(lambda x: os.path.realpath(x)[5:], scsiutil._genReverseSCSIidmap(rawdev.split('/')[-1]))
 
     for d in devices:
-        path = "/sys/block/%s/queue/scheduler" % d
-        if not os.path.exists(path):
-            SMlog("no path %s" % path)
-            return
-        try:
-            f = open(path, 'w')
-            f.write("%s\n" % str)
-            f.close()
-            SMlog("Set scheduler to [%s] on dev [%s]" % (str,d))
-        except:
-            SMlog("Error setting scheduler to [%s] on dev [%s]" % (str,d))
-            pass
+        set_scheduler_sysfs_node("/sys/block/%s" % d, str)
 
 # This function queries XAPI for the existing VDI records for this SR
 def _getVDIs(srobj):


### PR DESCRIPTION
With newer kernels, changing the scheduler in-kernel shortly after
device creation can deadlock. Instead, have SM set the scheduler. This
kind of policy decision is better kept in userspace anyway.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>