### PR TITLE
CA-312605: Fist point to allow configuration of pause in _gcLoop. Pau…

### DIFF
--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1130,6 +1130,9 @@ class FistPoint:
         #SMlog("Fist points loaded")
         self.points = points
 
+    def is_legal(self, name):
+        return (name in self.points)
+
     def is_active(self, name):
         return os.path.exists("/tmp/fist_%s" % name)
 
@@ -1167,6 +1170,8 @@ def list_find(f, seq):
     for item in seq:
         if f(item): 
             return item
+
+GCPAUSE_FISTPOINT = "GCLoop_no_pause"
 
 fistpoint = FistPoint( ["LVHDRT_finding_a_suitable_pair", 
                         "LVHDRT_inflating_the_parent", 
@@ -1213,7 +1218,8 @@ fistpoint = FistPoint( ["LVHDRT_finding_a_suitable_pair",
                         "testsm_clone_allow_raw",
                         "xenrt_default_vdi_type_legacy",
                         "blktap_activate_inject_failure",
-                        "blktap_activate_error_handling"] )
+                        "blktap_activate_error_handling",
+                        GCPAUSE_FISTPOINT] )
 
 def set_dirty(session, sr):
     try:

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,5 +1,6 @@
 import unittest
 import mock
+import __builtin__
 
 import cleanup
 
@@ -29,6 +30,11 @@ class AlwaysFreeLock(object):
         return True
 
 
+class TestRelease(object):
+    def release(self):
+        None
+
+
 class IrrelevantLock(object):
     pass
 
@@ -52,9 +58,28 @@ class TestSR(unittest.TestCase):
 
         ipc_mock.return_value = flag
 
+    def setup_flag_set(self, ipc_mock):
+        flag = mock.Mock()
+        flag.set = mock.Mock(return_value=False)
+
+        ipc_mock.return_value = flag
+
+    def setup_mock_sr(selfs, mock_sr):
+        xapi = FakeXapi()
+        mock_sr.configure_mock(uuid=1234, xapi=xapi,
+                               createLock=False, force=False)
+
+    def mock_cleanup_locks(self):
+        cleanup.lockActive = TestRelease()
+        cleanup.lockActive.release = mock.Mock(return_value=None)
+
+        cleanup.lockRunning = TestRelease()
+        cleanup.lockRunning.release = mock.Mock(return_value=None)
+
     def test_lock_if_already_locked(self):
         """
-        Given an already locked SR, a lock call increments the lock counter
+        Given an already locked SR, a lock call
+        increments the lock counter
         """
 
         sr = create_cleanup_sr()
@@ -67,7 +92,8 @@ class TestSR(unittest.TestCase):
 
     def test_lock_if_no_locking_is_used(self):
         """
-        Given no srLock present, the lock operations don't touch the counter
+        Given no srLock present, the lock operations don't touch
+        the counter
         """
 
         sr = create_cleanup_sr()
@@ -135,7 +161,313 @@ class TestSR(unittest.TestCase):
 
         try:
             sr.lock()
-        except:
+        except (util.SMException, cleanup.AbortException) as e:
             pass
 
         self.assertEquals(0, sr._locked)
+
+    def test_gcPause_fist_point_legal(self):
+        """
+        Make sure the fist point has been added to the array of legal
+        fist points.
+        """
+        self.assertTrue(util.fistpoint.is_legal(util.GCPAUSE_FISTPOINT))
+
+    @mock.patch('util.fistpoint', autospec=True)
+    @mock.patch('cleanup.SR', autospec=True)
+    @mock.patch('cleanup.Util.runAbortable')
+    def test_gcPause_calls_fist_point(
+            self,
+            mock_abortable,
+            mock_sr,
+            mock_fist):
+        """
+        Call fist point if active and not abortable sleep.
+        """
+        self.setup_mock_sr(mock_sr)
+
+        # Fake that we have an active fist point.
+        mock_fist.is_active.return_value = True
+
+        cleanup._gcLoopPause(mock_sr, False)
+
+        # Make sure we check for correct fist point.
+        mock_fist.is_active.assert_called_with(util.GCPAUSE_FISTPOINT)
+
+        # Make sure we are calling the fist point.
+        mock_fist.activate_custom_fn.assert_called_with(util.GCPAUSE_FISTPOINT,
+                                                        mock.ANY)
+
+        # And don't call abortable sleep
+        mock_abortable.assert_not_called()
+
+    @mock.patch('util.fistpoint', autospec=True)
+    @mock.patch('cleanup.SR', autospec=True)
+    @mock.patch('cleanup.Util.runAbortable')
+    def test_gcPause_calls_abortable_sleep(
+            self,
+            mock_abortable,
+            mock_sr,
+            mock_fist_point):
+        """
+        Call abortable sleep if fist point is not active.
+        """
+        self.setup_mock_sr(mock_sr)
+
+        # Fake that the fist point is not active.
+        mock_fist_point.is_active.return_value = False
+
+        cleanup._gcLoopPause(mock_sr, False)
+
+        # Make sure we check for the active fist point.
+        mock_fist_point.is_active.assert_called_with(util.GCPAUSE_FISTPOINT)
+
+        # Fist point is not active so call abortable sleep.
+        mock_abortable.assert_called_with(mock.ANY, None, mock_sr.uuid,
+                                          mock.ANY, cleanup.VDI.POLL_INTERVAL,
+                                          cleanup.GCPAUSE_DEFAULT_SLEEP * 1.1)
+
+    @mock.patch('cleanup.SR', autospec=True)
+    @mock.patch('cleanup._abort')
+    def test_lock_released_by_abort_when_held(
+            self,
+            mock_abort,
+            mock_sr):
+        """
+        If _abort returns True make sure we release the lockActive which will
+        have been held by _abort, also check that we return True.
+        """
+        self.setup_mock_sr(mock_sr)
+
+        # Fake that abort returns True, so we hold lockActive.
+        mock_abort.return_value = True
+
+        # Setup mock of release function.
+        cleanup.lockActive = TestRelease()
+        cleanup.lockActive.release = mock.Mock(return_value=None)
+
+        ret = cleanup.abort(mock_sr, False)
+
+        # Pass on the return from _abort.
+        self.assertEquals(True, ret)
+
+        # We hold lockActive so make sure we release it.
+        self.assertEquals(cleanup.lockActive.release.call_count, 1)
+
+    @mock.patch('cleanup.SR', autospec=True)
+    @mock.patch('cleanup._abort')
+    def test_lock_not_released_by_abort_when_not_held(
+            self,
+            mock_abort,
+            mock_sr):
+        """
+        If _abort returns False don't release lockActive and ensure that
+        False returned by _abort is passed on.
+        """
+        self.setup_mock_sr(mock_sr)
+
+        # Fake _abort returning False.
+        mock_abort.return_value = False
+
+        # Mock lock release function.
+        cleanup.lockActive = TestRelease()
+        cleanup.lockActive.release = mock.Mock(return_value=None)
+
+        ret = cleanup.abort(mock_sr, False)
+
+        # Make sure pass on False returned by _abort
+        self.assertEquals(False, ret)
+
+        # Make sure we did not release the lock as we don't have it.
+        self.assertEquals(cleanup.lockActive.release.call_count, 0)
+
+    @mock.patch('cleanup._abort')
+    @mock.patch.object(__builtin__, 'raw_input')
+    def test_abort_optional_renable_active_held(
+            self,
+            mock_raw_input,
+            mock_abort):
+        """
+        Cli has option to re enable gc make sure we release the locks
+        correctly if _abort returns True.
+        """
+        mock_abort.return_value = True
+        mock_raw_input.return_value = None
+
+        self.mock_cleanup_locks()
+
+        cleanup.abort_optional_reenable(None)
+
+        # Make sure released lockActive
+        self.assertEquals(cleanup.lockActive.release.call_count, 1)
+
+        # Make sure released lockRunning
+        self.assertEquals(cleanup.lockRunning.release.call_count, 1)
+
+    @mock.patch('cleanup._abort')
+    @mock.patch.object(__builtin__, 'raw_input')
+    def test_abort_optional_renable_active_not_held(
+            self,
+            mock_raw_input,
+            mock_abort):
+        """
+        Cli has option to reenable gc make sure we release the locks
+        correctly if _abort return False.
+        """
+        mock_abort.return_value = False
+        mock_raw_input.return_value = None
+
+        self.mock_cleanup_locks()
+
+        cleanup.abort_optional_reenable(None)
+
+        # Don't release lockActive, we don't hold it.
+        self.assertEquals(cleanup.lockActive.release.call_count, 0)
+
+        # Make sure released lockRunning
+        self.assertEquals(cleanup.lockRunning.release.call_count, 1)
+
+    @mock.patch('cleanup.init')
+    def test__abort_returns_true_when_get_lock(
+            self,
+            mock_init):
+        """
+        _abort should return True when it can get
+        the lockActive straight off the bat.
+        """
+        cleanup.lockActive = AlwaysFreeLock()
+        ret = cleanup._abort(None)
+        self.assertEquals(ret, True)
+
+    @mock.patch('cleanup.IPCFlag', autospec=True)
+    @mock.patch('cleanup.init')
+    def test__abort_return_false_if_flag_not_set(
+            self,
+            mock_init,
+            mock_ipcflag):
+        """
+        If flag not set return False.
+        """
+        mock_init.return_value = None
+
+        # Fake the flag returning False.
+        mock_ipcflag.return_value.set.return_value = False
+
+        # Not important for this test but we call it so mock it.
+        cleanup.lockActive = AlwaysLockedLock()
+
+        ret = cleanup._abort(None)
+
+        self.assertEqual(mock_ipcflag.return_value.set.call_count, 1)
+        self.assertEqual(ret, False)
+
+    @mock.patch('cleanup.IPCFlag', autospec=True)
+    @mock.patch('cleanup.init')
+    def test__abort_should_raise_if_cant_get_lock(
+            self,
+            mock_init,
+            mock_ipcflag):
+        """
+        _abort should raise an exception if it completely
+        fails to get lockActive.
+        """
+        mock_init.return_value = None
+
+        # Fake return true so we don't bomb out straight away.
+        mock_ipcflag.return_value.set.return_value = True
+
+        # Fake never getting the lock.
+        cleanup.lockActive = AlwaysLockedLock()
+
+        with self.assertRaises(util.CommandException):
+            cleanup._abort(None)
+
+    @mock.patch('cleanup.IPCFlag', autospec=True)
+    @mock.patch('cleanup.init')
+    def test__abort_should_succeed_if_aquires_on_second_attempt(
+            self,
+            mock_init,
+            mock_ipcflag):
+        """
+        _abort should succeed if gets lock on second attempt
+        """
+        mock_init.return_value = None
+
+        # Fake return true so we don't bomb out straight away.
+        mock_ipcflag.return_value.set.return_value = True
+
+        # Use side effect to fake failing to get the lock
+        # on the first call, succeeding on the second.
+        mocked_lock = AlwaysLockedLock()
+        mocked_lock.acquireNoblock = mock.Mock()
+        mocked_lock.acquireNoblock.side_effect = [False, True]
+        cleanup.lockActive = mocked_lock
+
+        ret = cleanup._abort(None)
+
+        self.assertEqual(mocked_lock.acquireNoblock.call_count, 2)
+        self.assertEqual(ret, True)
+
+    @mock.patch('cleanup.IPCFlag', autospec=True)
+    @mock.patch('cleanup.init')
+    def test__abort_should_fail_if_reaches_maximum_retries_for_lock(
+            self,
+            mock_init,
+            mock_ipcflag):
+        """
+        _abort should fail if we max out the number of attempts for
+        obtaining the lock.
+        """
+        mock_init.return_value = None
+
+        # Fake return true so we don't bomb out straight away.
+        mock_ipcflag.return_value.set.return_value = True
+
+        # Fake a series of failed attempts to get the lock.
+        mocked_lock = AlwaysLockedLock()
+        mocked_lock.acquireNoblock = mock.Mock()
+
+        # +1 to SR.LOCK_RETRY_ATTEMPTS as we attempt to get lock
+        # once outside the loop.
+        side_effect = [False]*(cleanup.SR.LOCK_RETRY_ATTEMPTS + 1)
+
+        # Make sure we are not trying once again
+        side_effect.append(True)
+
+        mocked_lock.acquireNoblock.side_effect = side_effect
+        cleanup.lockActive = mocked_lock
+
+        # We've failed repeatedly to gain the lock so raise exception.
+        with self.assertRaises(util.CommandException):
+            cleanup._abort(None)
+            self.assertEqual(mocked_lock.acquireNoblock.call_count,
+                             cleanup.SR.LOCK_RETRY_ATTEMPTS+1)
+
+    @mock.patch('cleanup.IPCFlag', autospec=True)
+    @mock.patch('cleanup.init')
+    def test__abort_succeeds_if_gets_lock_on_final_attempt(
+            self,
+            mock_init,
+            mock_ipcflag):
+        """
+        _abort succeeds if we get the lockActive on the final retry
+        """
+        mock_init.return_value = None
+        mock_ipcflag.return_value.set.return_value = True
+        mocked_lock = AlwaysLockedLock()
+        mocked_lock.acquireNoblock = mock.Mock()
+
+        # +1 to SR.LOCK_RETRY_ATTEMPTS as we attempt to get lock
+        # once outside the loop.
+        side_effect = [False]*(cleanup.SR.LOCK_RETRY_ATTEMPTS)
+
+        # On the final attempt we succeed.
+        side_effect.append(True)
+
+        mocked_lock.acquireNoblock.side_effect = side_effect
+        cleanup.lockActive = mocked_lock
+
+        ret = cleanup._abort(None)
+        self.assertEqual(mocked_lock.acquireNoblock.call_count,
+                         cleanup.SR.LOCK_RETRY_ATTEMPTS+1)
+        self.assertEqual(ret, True)


### PR DESCRIPTION
This code works in conjunction with the XenRT branch private/**my_user_name**/CA-310988, there will be no ill effects if the pulls are not synced.

If the fist point is active (XenRT Job 2464771) the SMLog looks like this.
```
Mar 29 09:43:59 localhost SM: [24323] vdi_delete {'sr_uuid': 'ca854f7e-6307-936e-a888-9f57a82c88bd', 'subtask_of': 'DummyRef:|faf71700-c991-4fbc-a22d-f0341e7edd66|VDI.destroy', 'vdi_ref': 'OpaqueRef:b8999ac6-0bc6-43df-aedb-9d1b563973bd', 'vdi_on_boot': 'persist', 'args': [], 'o_direct': False, 'vdi_location': 'a72fee38-a4c5-4bad-90df-d7e2bd2d39f1', 'host_ref': 'OpaqueRef:1a23c3cf-c346-4e1e-ac8a-16163070ce69', 'session_ref': 'OpaqueRef:45120771-e20f-4d18-a6e4-46061fdbd890', 'device_config': {'device': '/dev/disk/by-id/scsi-36b083fe0d7dfbd001c124fde10182533-part3', 'SRmaster': 'true'}, 'command': 'vdi_delete', 'vdi_allow_caching': 'false', 'sr_ref': 'OpaqueRef:b3297fa6-23d0-4fe3-a2c5-b32d8352112c', 'local_cache_sr': 'ca854f7e-6307-936e-a888-9f57a82c88bd', 'vdi_uuid': 'a72fee38-a4c5-4bad-90df-d7e2bd2d39f1'}
Mar 29 09:44:00 localhost SM: [24323] lock: unlinking lock file /var/lock/sm/a72fee38-a4c5-4bad-90df-d7e2bd2d39f1/vdi
Mar 29 09:44:00 localhost SM: [24323] lock: removing lock dir /var/lock/sm/a72fee38-a4c5-4bad-90df-d7e2bd2d39f1
Mar 29 09:44:00 localhost SM: [24323] lock: opening lock file /var/lock/sm/ca854f7e-6307-936e-a888-9f57a82c88bd/running
Mar 29 09:44:00 localhost SM: [24323] lock: tried lock /var/lock/sm/ca854f7e-6307-936e-a888-9f57a82c88bd/running, acquired: True (exists: True)
Mar 29 09:44:00 localhost SM: [24323] lock: released /var/lock/sm/ca854f7e-6307-936e-a888-9f57a82c88bd/running
Mar 29 09:44:00 localhost SM: [24323] Kicking GC
Mar 29 09:44:00 localhost SMGC: [24323] === SR ca854f7e-6307-936e-a888-9f57a82c88bd: gc ===
Mar 29 09:44:00 localhost SMGC: [24349] Will finish as PID [24350]
Mar 29 09:44:00 localhost SM: [24350] lock: opening lock file /var/lock/sm/ca854f7e-6307-936e-a888-9f57a82c88bd/running
Mar 29 09:44:00 localhost SM: [24350] lock: opening lock file /var/lock/sm/ca854f7e-6307-936e-a888-9f57a82c88bd/gc_active
Mar 29 09:44:00 localhost SMGC: [24323] New PID [24349]
Mar 29 09:44:00 localhost SM: [24323] lock: closed /var/lock/sm/ca854f7e-6307-936e-a888-9f57a82c88bd/running
Mar 29 09:44:00 localhost SM: [24350] lock: opening lock file /var/lock/sm/ca854f7e-6307-936e-a888-9f57a82c88bd/sr
Mar 29 09:44:00 localhost SM: [24323] lock: released /var/lock/sm/ca854f7e-6307-936e-a888-9f57a82c88bd/sr
Mar 29 09:44:00 localhost SM: [24323] lock: closed /var/lock/sm/ca854f7e-6307-936e-a888-9f57a82c88bd/sr
Mar 29 09:44:00 localhost SMGC: [24350] Found 0 cache files
Mar 29 09:44:00 localhost SM: [24350] lock: tried lock /var/lock/sm/ca854f7e-6307-936e-a888-9f57a82c88bd/gc_active, acquired: True (exists: True)
Mar 29 09:44:00 localhost SM: [24350] Executing fist point GCLoop_no_pause: starting ...
Mar 29 09:44:00 localhost SM: [24350] Executing fist point GCLoop_no_pause: done localhost SM: 
```
Note the fist point returning pretty much instantly. When we don't have the active fist point, we fall back on a five minute sleep but now this is in an abortable child process (XenRT job  2464799)
```
Mar 29 11:33:06 localhost SMGC: [24555] GC active, about to go quiet
yadda yadda yadda
...
...
yadda yadda yadda
Mar 29 11:38:06 localhost SM: [24577] IPCFlag: set faae21d4-7576-0af3-0bdb-63342bea57cb:success
Mar 29 11:38:06 localhost SMGC: [24555]   Child process completed successfully
Mar 29 11:38:06 localhost SM: [24555] IPCFlag: clear faae21d4-7576-0af3-0bdb-63342bea57cb:success
Mar 29 11:38:06 localhost SMGC: [24555] GC active, quiet period ended
```
I am currently running the Storage BST (Job Id 103101) hopefully this should be a lot quicker now and also be clean.