### PR TITLE
CA-314717 Explicit stdout and stderr for scan services

### DIFF
--- a/systemd/mpathcount.service
+++ b/systemd/mpathcount.service
@@ -3,5 +3,7 @@ Description=Multipath scanner
 
 [Service]
 StandardInput=socket
+StandardOutput=null
+StandardError=journal
 ExecStart=/usr/bin/sh -c '. /etc/xensource-inventory; while dd of=/dev/null bs=4096 count=1 status=none conv=noerror; do /opt/xensource/sm/mpathcount.py; done'
 Restart=always

--- a/systemd/usb-scan.service
+++ b/systemd/usb-scan.service
@@ -3,5 +3,7 @@ Description=USB device scanner
 
 [Service]
 StandardInput=socket
+StandardOutput=null
+StandardError=journal
 ExecStart=/usr/bin/sh -c '. /etc/xensource-inventory; while dd of=/dev/null bs=4096 count=1 status=none conv=noerror; do /opt/xensource/bin/xe pusb-scan host-uuid=$${INSTALLATION_UUID}; done'
 Restart=always


### PR DESCRIPTION
Since these are kicked by a pipe, explicitly prevent systemd from
putting their stdout and stderr on the same pipe so that they can't kick
themselves.