### PR TITLE
Avoid getting exceptions logged from checking if an lv exists

### DIFF
--- a/drivers/lvutil.py
+++ b/drivers/lvutil.py
@@ -545,12 +545,8 @@ def setReadonly(path, readonly):
     ret = cmd_lvm([CMD_LVCHANGE, path, "-p", val], pread_func=util.pread)
 
 def exists(path):
-    try:
-        ret = cmd_lvm([CMD_LVS, "--noheadings", path])
-        return True
-    except util.CommandException, e:
-        util.SMlog("Ignoring exception for LV check: %s !" % path)
-        return False
+    (rc, stdout, stderr) = cmd_lvm([CMD_LVS, "--noheadings", path], pread_func=util.doexec)
+    return rc == 0
 
 def setSize(path, size, confirm):
     sizeMB = size / (1024 * 1024)


### PR DESCRIPTION
CBT code make many checks for the existence of the cbtlog volume but if CBT is not enabled this logs exceptions when the volume is not found. Use doexec directly and check if the return code is 0 or not.