### PR TITLE
CA-314822: use scanLocked in should_prempt

### DIFF
--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -2803,7 +2803,7 @@ def should_preempt(session, srUuid):
         return False
     elif len(entries) > 1:
         raise util.SMException("More than one coalesce entry: " + str(entries))
-    sr.scan()
+    sr.scanLocked()
     coalescedUuid = entries.popitem()[0]
     garbage = sr.findGarbage()
     for vdi in garbage:


### PR DESCRIPTION
To avoid SR contents changing during scan

Signed-off-by: Mark Syms <mark.syms@citrix.com>