### PR TITLE
CA-324815: lock the SR in GC before deleting orphans.

### DIFF
--- a/drivers/lock.py
+++ b/drivers/lock.py
@@ -69,6 +69,14 @@ class Lock(object):
         return ns
     _mknamespace = staticmethod(_mknamespace)
 
+    @staticmethod
+    def clearAll():
+        """
+        Drop all lock instances, to be used when forking, but not execing
+        """
+        Lock.INSTANCES = {}
+        Lock.BASE_INSTANCES = {}
+
     def cleanup(name, ns = None):
         if ns:
             if ns in Lock.INSTANCES:


### PR DESCRIPTION
Also ensure lock objects are reset on forking the GC.

Signed-off-by: Mark Syms <mark.syms@citrix.com>