### PR TITLE
CP-32433: kick the multipath and usb scanners at start

### DIFF
--- a/systemd/mpathcount.service
+++ b/systemd/mpathcount.service
@@ -8,5 +8,4 @@ StandardInput=socket
 StandardOutput=null
 StandardError=journal
 ExecStart=/usr/bin/sh -c '. /etc/xensource-inventory; while dd of=/dev/null bs=4096 count=1 status=none conv=noerror; do /opt/xensource/sm/mpathcount.py; done'
-ExecStartPost=/opt/xensource/libexec/kickpipe mpathcount
 Restart=always

--- a/systemd/mpathcount.socket
+++ b/systemd/mpathcount.socket
@@ -4,6 +4,7 @@ Description=Multipath scanner kick socket
 [Socket]
 ListenFIFO=/var/run/mpathcount.sock
 PipeSize=4096
+ExecStartPost=/opt/xensource/libexec/kickpipe mpathcount
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/usb-scan.service
+++ b/systemd/usb-scan.service
@@ -8,5 +8,4 @@ StandardInput=socket
 StandardOutput=null
 StandardError=journal
 ExecStart=/usr/bin/sh -c '. /etc/xensource-inventory; while dd of=/dev/null bs=4096 count=1 status=none conv=noerror; do /opt/xensource/bin/xe pusb-scan host-uuid=$${INSTALLATION_UUID}; done'
-ExecStartPost=/opt/xensource/libexec/kickpipe usb-scan
 Restart=always

--- a/systemd/usb-scan.socket
+++ b/systemd/usb-scan.socket
@@ -4,6 +4,7 @@ Description=USB device scanner kick socket
 [Socket]
 ListenFIFO=/var/run/usb-scan.sock
 PipeSize=4096
+ExecStartPost=/opt/xensource/libexec/kickpipe usb-scan
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
ExcecPostStart needs to be in the socket files not the service files, only the sockets are
auto-enabled,

Signed-off-by: Mark Syms <mark.syms@citrix.com>