### PR TITLE
Replacing ls command with "find" enables a depth parameter to be set 

### DIFF
--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -657,6 +657,6 @@ class ISOVDI(VDI.VDI):
     # exceptions 
 
 if __name__ == '__main__':
-        SRCommand.run(ISOSR, DRIVER_INFO)
-    else:
-        SR.registerSR(ISOSR)
+    SRCommand.run(ISOSR, DRIVER_INFO)
+else:
+    SR.registerSR(ISOSR)

--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -119,8 +119,8 @@ class ISOSR(SR.SR):
             return
 
         for name in filter(is_image_utf8_compatible,
-                util.listdir(self.path, quiet = True)):
-	    fileName = self.path + "/" + name
+                util.listdir(self.path, quiet = True, depth=10)):
+            fileName = self.path + "/" + name
             if os.path.isdir(fileName):
                 util.SMlog("_loadvdis : %s is a directory. Ignore" % fileName)
                 continue
@@ -657,6 +657,16 @@ class ISOVDI(VDI.VDI):
     # exceptions 
 
 if __name__ == '__main__':
-    SRCommand.run(ISOSR, DRIVER_INFO)
-else:
-    SR.registerSR(ISOSR)
+    from pathlib import Path, PureWindowsPath
+    # Convert path to the right format for the current operating system
+    correct_path = Path('C:/Users/kuzko')
+
+    for name in filter(is_image_utf8_compatible, util.listdir(".", quiet=True)):
+        fileName = correct_path + "/" + name
+        if os.path.isdir(fileName):
+            print("_loadvdis : %s is a directory. Ignore" % fileName)
+            continue
+
+#     SRCommand.run(ISOSR, DRIVER_INFO)
+# else:
+#     SR.registerSR(ISOSR)

--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -657,16 +657,6 @@ class ISOVDI(VDI.VDI):
     # exceptions 
 
 if __name__ == '__main__':
-    from pathlib import Path, PureWindowsPath
-    # Convert path to the right format for the current operating system
-    correct_path = Path('C:/Users/kuzko')
-
-    for name in filter(is_image_utf8_compatible, util.listdir(".", quiet=True)):
-        fileName = correct_path + "/" + name
-        if os.path.isdir(fileName):
-            print("_loadvdis : %s is a directory. Ignore" % fileName)
-            continue
-
-#     SRCommand.run(ISOSR, DRIVER_INFO)
-# else:
-#     SR.registerSR(ISOSR)
+        SRCommand.run(ISOSR, DRIVER_INFO)
+    else:
+        SR.registerSR(ISOSR)

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -208,8 +208,8 @@ def pread3(cmdlist, text):
     SMlog("  pread3 SUCCESS")
     return stdout
 
-def listdir(path, quiet = False):
-    cmd = ["ls", path, "-1", "--color=never"]
+def listdir(path, quiet = False, depth = 1):
+    cmd = ["find", path, "-maxdepth", str(depth)]
     try:
         text = pread2(cmd, quiet = quiet)[:-1]
         if len(text) == 0:


### PR DESCRIPTION
Created to solve : https://github.com/xcp-ng/xcp/issues/313
it's tested to not be impacting other commands on my XCP-NG and shouldn't impacting other commands.
The project maintainers might want to set a more conservative default, but I haven't see a major impact on our 20.000 files smb share.
