### PR TITLE
CA-332806 - Fix type mismatch when processing speed file

### DIFF
--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -1948,7 +1948,13 @@ class SR:
             if os.path.isfile(path):
                 speedFile = open(path)
                 content = speedFile.readlines()
-                content = [float(i) for i in content]
+                try:
+                    content = [float(i) for i in content]
+                except exceptions.ValueError:
+                    Util.log("Something bad in the speed log:{log}".
+                             format(log=speedFile.readlines()))
+                    return speed
+
                 if len(content):
                     speed = sum(content)/float(len(content))
                     if speed <= 0:

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -967,6 +967,10 @@ class TestSR(unittest.TestCase):
         self.getStorageSpeed(mock_isFile, sr, fakeFile, True, 3.0, 1,
                              lines=[1.0, 2.0, 6.0])
 
+        # File exists contains, a string
+        self.getStorageSpeed(mock_isFile, sr, fakeFile, True, None, 1,
+                             lines=[1.0, 2.0, "Hello"])
+
     def speedFileSetup(self, sr, FakeFile, mock_isFile, isFile):
         expectedPath = cleanup.SPEED_LOG_ROOT.format(uuid=sr.uuid)
         mock_isFile.return_value = isFile


### PR DESCRIPTION
Defensive coding, in case the speedlog is overwritten with junk.