### PR TITLE
Fix xe-mount-iso-sr command name in error message

### DIFF
--- a/drivers/XE_SR_ERRORCODES.xml
+++ b/drivers/XE_SR_ERRORCODES.xml
@@ -101,7 +101,7 @@
         </code>
         <code>
                 <name>ISOInvalidXeMountOptions</name>
-                <description>Require "-o" along with xe-mount-isosr</description>
+                <description>Require "-o" along with xe-mount-iso-sr</description>
                 <value>228</value>
         </code>
 


### PR DESCRIPTION
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>