### PR TITLE
CA-332890: evaluate multipath on device change as well as add.

### DIFF
--- a/udev/65-multipath.rules
+++ b/udev/65-multipath.rules
@@ -8,9 +8,17 @@ ACTION=="remove", ENV{DM_MULTIPATH_DEVICE_PATH}=="1",  GOTO="count_mpath"
 IMPORT{db}="DM_ACTION"
 ACTION=="change", ENV{DM_ACTION}=="PATH_REINSTATED", GOTO="count_mpath"
 ACTION=="change", ENV{DM_ACTION}=="PATH_FAILED", GOTO="count_mpath"
+
 IMPORT{db}="CH_MULTIPATH"
-ACTION=="add", PROGRAM=="/bin/bash -c '/sbin/dmsetup table -j %M -m %m | /bin/grep multipath'", ENV{CH_MULTIPATH}="1"
-ACTION=="add|remove", ENV{CH_MULTIPATH}=="1", GOTO="count_mpath"
+# MP device removed, count
+ACTION=="remove", ENV{CH_MULTIPATH}=="1", GOTO="count_mpath"
+
+# Already counted so skip
+ENV{CH_MULTIPATH}=="1", GOTO="end_mpath"
+
+# Check added or changed for being multipath
+ACTION=="add|change", PROGRAM=="/bin/bash -c '/sbin/dmsetup table -j %M -m %m | /bin/grep multipath'", ENV{CH_MULTIPATH}="1"
+ENV{CH_MULTIPATH}=="1", GOTO="count_mpath"
 GOTO="end_mpath"
 
 LABEL="count_mpath"


### PR DESCRIPTION
It seems that whilst in a large majority of cases a device add event
will also have all the kernel mulitpath data setup it sometimes doesn't
and we need to look at the data when we get a subsequent device change
event.

In order to not trigger the count script unneccessarily we

  * Read the CH_MULTIPATH value from the udev data, this can only have
    been set by a previous device add/change. If this is set and we are
    removing the device we need to count. If it is set for any other
    event, then we have already performed a path count so skip to end.
  * If a device add/change event is received, check the DM table to
    see if this is a multipath device. If it is then set the CH_MULTIPATH
    variable and count.

Signed-off-by: Mark Syms <mark.syms@citrix.com>