### PR TITLE
Changed default NFS SR mount from soft to hard

### DIFF
--- a/drivers/NFSSR.py
+++ b/drivers/NFSSR.py
@@ -2,13 +2,13 @@
 #
 # Copyright (C) Citrix Systems Inc.
 #
-# This program is free software; you can redistribute it and/or modify 
-# it under the terms of the GNU Lesser General Public License as published 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
 # by the Free Software Foundation; version 2.1 only.
 #
-# This program is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
@@ -126,7 +126,7 @@ class NFSSR(FileSR.FileSR):
 
     def mount(self, mountpoint, remotepath, timeout=None, retrans=None):
         try:
-            nfs.soft_mount(
+            nfs.mount(
                     mountpoint, self.remoteserver, remotepath, self.transport,
                     useroptions=self.options, timeout=timeout,
                     nfsversion=self.nfsversion, retrans=retrans)

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1020,6 +1020,7 @@ class VDI(object):
         self.__o_direct  = None
         self.__o_direct_reason = None
         self.lock        = Lock("vdi", uuid)
+        self.tap         = None
 
     def get_o_direct_capability(self, options):
         """Returns True/False based on licensing and caching_params"""

--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -47,7 +47,7 @@ SHOWMOUNT_BIN = "/usr/sbin/showmount"
 
 DEFAULT_NFSVERSION = '3'
 
-DEFUAULT_RECOVERY_MODE = 'hard'
+DEFAULT_RECOVERY_MODE = 'hard'
 
 NFS_VERSION = [
     'nfsversion', 'for type=nfs, NFS protocol version - 3, 4, 4.1']

--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -121,7 +121,7 @@ def validate_nfsversion(nfsversion):
 
 
 def soft_mount(mountpoint, remoteserver, remotepath, transport, useroptions='',
-               timeout=None, nfsversion=DEFAULT_NFSVERSION, recovery_mode='soft', retrans=None):
+               timeout=None, nfsversion=DEFAULT_NFSVERSION, retrans=None):
     """Backward compatibility for ISOSR.py and other NFS mount calls.
     calls the 'real' mount function 'mount'
     """

--- a/tests/test_NFSSR.py
+++ b/tests/test_NFSSR.py
@@ -67,12 +67,12 @@ class TestNFSSR(unittest.TestCase):
 
     @mock.patch('util.makedirs', autospec=True)
     @mock.patch('NFSSR.Lock', autospec=True)
-    @mock.patch('nfs.soft_mount', autospec=True)
+    @mock.patch('nfs.mount', autospec=True)
     @mock.patch('util._testHost', autospec=True)
     @mock.patch('nfs.check_server_tcp', autospec=True)
     @mock.patch('nfs.validate_nfsversion', autospec=True)
     def test_attach(self, validate_nfsversion, check_server_tcp, _testhost,
-                    soft_mount, Lock, makedirs):
+                    mount, Lock, makedirs):
         validate_nfsversion.return_value = "aNfsversionChanged"
         nfssr = self.create_nfssr(server='aServer', serverpath='/aServerpath',
                                   sr_uuid='UUID', useroptions='options')
@@ -81,7 +81,7 @@ class TestNFSSR(unittest.TestCase):
 
         check_server_tcp.assert_called_once_with('aServer',
                                                  'aNfsversionChanged')
-        soft_mount.assert_called_once_with('/var/run/sr-mount/UUID',
+        mount.assert_called_once_with('/var/run/sr-mount/UUID',
                                            'aServer',
                                            '/aServerpath/UUID',
                                            'tcp',

--- a/tests/test_blktap2.py
+++ b/tests/test_blktap2.py
@@ -2,6 +2,7 @@ import unittest
 import blktap2
 import mock
 import testlib
+import os
 
 
 class TestVDI(unittest.TestCase):
@@ -29,3 +30,87 @@ class TestVDI(unittest.TestCase):
         result = self.vdi.get_tap_type()
 
         self.assertEquals('aio', result)
+
+    class NBDLinkForTest(blktap2.VDI.NBDLink):
+        __name__ = "bob"
+
+    @mock.patch('blktap2.VDI.NBDLink', autospec=NBDLinkForTest)
+    @mock.patch('blktap2.VDI.NBDLink', autospec=NBDLinkForTest)
+    def test_linknbd(self, nbd_link2, nbd_link):
+        self.vdi.tap = blktap2.Tapdisk(123, 456, "blah", "blah", "blah")
+        nbd_link.from_uuid.return_value = nbd_link2
+        self.vdi.linkNBD("blahblah", "yadayada")
+        expected_path = '/run/blktap-control/nbd%d.%d' % (123, 456)
+        nbd_link.from_uuid.assert_called_with("blahblah", "yadayada")
+        nbd_link2.mklink.assert_called_with(expected_path)
+
+    def reset_removedirmocks(self, mock_rmdir, mock_unlink, mock_listdir,
+                             mock_split, mock_lexists):
+        mock_rmdir.reset_mock()
+        mock_unlink.reset_mock()
+        mock_listdir.reset_mock()
+        mock_split.reset_mock()
+        mock_lexists.reset_mock()
+
+    @mock.patch("blktap2.os.path.lexists", autospec=True)
+    @mock.patch("blktap2.os.path.split", autospec=True)
+    @mock.patch("blktap2.os.listdir", autospec=True)
+    @mock.patch("blktap2.os.unlink", autospec=True)
+    @mock.patch("blktap2.os.rmdir", autospec=True)
+    def test_removedirs(self, mock_rmdir, mock_unlink, mock_listdir,
+                        mock_split, mock_lexists):
+        # Path does not exist
+        mock_lexists.return_value = False
+        blktap2.rmdirs("blah/blah1/blah2.txt")
+        mock_lexists.assert_called_with("blah/blah1/blah2.txt")
+        self.assertEquals(mock_split.call_count, 0)
+
+        self.reset_removedirmocks(mock_rmdir, mock_unlink,
+                                  mock_listdir, mock_split, mock_lexists)
+        # Split returns nothing.
+        mock_lexists.return_value = True
+        mock_split.return_value = [None, None]
+        blktap2.rmdirs("blah/blah1/blah2.txt")
+        mock_lexists.assert_called_with("blah/blah1/blah2.txt")
+        mock_split.assert_called_with("blah/blah1/blah2.txt")
+        self.assertEquals(mock_rmdir.call_count, 0)
+        self.assertEquals(mock_unlink.call_count, 0)
+        self.assertEquals(mock_listdir.call_count, 0)
+
+        self.reset_removedirmocks(mock_rmdir, mock_unlink,
+                                  mock_listdir, mock_split, mock_lexists)
+        # Split returns single file.
+        mock_lexists.return_value = True
+        mock_split.return_value = [None, "blah.txt"]
+        blktap2.rmdirs("blah/blah1/blah2.txt")
+        mock_lexists.assert_called_with("blah/blah1/blah2.txt")
+        mock_split.assert_called_with("blah/blah1/blah2.txt")
+        self.assertEquals(mock_rmdir.call_count, 0)
+        self.assertEquals(mock_listdir.call_count, 0)
+        mock_unlink.assert_called_with("blah/blah1/blah2.txt")
+
+        self.reset_removedirmocks(mock_rmdir, mock_unlink,
+                                  mock_listdir, mock_split, mock_lexists)
+        # Split returns valid stuff. but directory is not empty
+        mock_lexists.return_value = True
+        mock_split.return_value = ["blah/blah1/", "blah2.txt"]
+        mock_listdir.return_value = ["stuff.txt", "more_stuff.txt"]
+        blktap2.rmdirs("blah/blah1/blah2.txt")
+        mock_lexists.assert_called_with("blah/blah1/blah2.txt")
+        mock_split.assert_called_with("blah/blah1/blah2.txt")
+        self.assertEquals(mock_rmdir.call_count, 0)
+        mock_listdir.assert_called_with("blah/blah1/")
+        mock_unlink.assert_called_with("blah/blah1/blah2.txt")
+
+        self.reset_removedirmocks(mock_rmdir, mock_unlink,
+                                  mock_listdir, mock_split, mock_lexists)
+        # Everything is good to remove
+        mock_lexists.return_value = True
+        mock_split.return_value = ["blah/blah1/", "blah2.txt"]
+        mock_listdir.return_value = []
+        blktap2.rmdirs("blah/blah1/blah2.txt")
+        mock_lexists.assert_called_with("blah/blah1/blah2.txt")
+        mock_split.assert_called_with("blah/blah1/blah2.txt")
+        mock_rmdir.assert_called_with("blah/blah1/")
+        mock_listdir.assert_called_with("blah/blah1/")
+        mock_unlink.assert_called_with("blah/blah1/blah2.txt")

--- a/tests/test_blktap2.py
+++ b/tests/test_blktap2.py
@@ -36,6 +36,12 @@ class TestVDI(unittest.TestCase):
 
     @mock.patch('blktap2.VDI.NBDLink', autospec=NBDLinkForTest)
     @mock.patch('blktap2.VDI.NBDLink', autospec=NBDLinkForTest)
+    def test_linknbd_not_called_for_no_tap(self, nbd_link2, nbd_link):
+        self.vdi.linkNBD("blahblah", "yadayada")
+        self.assertEquals(nbd_link.from_uuid.call_count, 0)
+
+    @mock.patch('blktap2.VDI.NBDLink', autospec=NBDLinkForTest)
+    @mock.patch('blktap2.VDI.NBDLink', autospec=NBDLinkForTest)
     def test_linknbd(self, nbd_link2, nbd_link):
         self.vdi.tap = blktap2.Tapdisk(123, 456, "blah", "blah", "blah")
         nbd_link.from_uuid.return_value = nbd_link2

--- a/tests/test_nfs.py
+++ b/tests/test_nfs.py
@@ -82,7 +82,7 @@ class Test_nfs(unittest.TestCase):
     @mock.patch('nfs.check_server_service', autospec=True)
     @mock.patch('util.pread', autospec=True)
     def test_soft_mount(self, pread, check_server_service, makedirs):
-        nfs.soft_mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
+        nfs.mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
                        timeout=None)
 
         check_server_service.assert_called_once_with('remoteserver')
@@ -94,7 +94,7 @@ class Test_nfs(unittest.TestCase):
     @mock.patch('util.pread', autospec=True)
     def test_soft_mount_nfsversion_3(self, pread, 
                                      check_server_service, makedirs):
-        nfs.soft_mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
+        nfs.mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
                        timeout=None, nfsversion='3')
 
         check_server_service.assert_called_once_with('remoteserver')
@@ -106,7 +106,7 @@ class Test_nfs(unittest.TestCase):
     @mock.patch('util.pread', autospec=True)
     def test_soft_mount_nfsversion_4(self, pread, 
                                      check_server_service, makedirs):
-        nfs.soft_mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
+        nfs.mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
                        timeout=None, nfsversion='4')
 
         check_server_service.assert_called_once_with('remoteserver')

--- a/tests/test_nfs.py
+++ b/tests/test_nfs.py
@@ -76,7 +76,7 @@ class Test_nfs(unittest.TestCase):
 
     def get_soft_mount_pread(self, binary, vers):
         return ([binary, 'remoteserver:remotepath', 'mountpoint', '-o',
-                 'soft,proto=transport,vers=%s,acdirmin=0,acdirmax=0' % vers])
+                 'hard,proto=transport,vers=%s,acdirmin=0,acdirmax=0' % vers])
 
     @mock.patch('util.makedirs', autospec=True)
     @mock.patch('nfs.check_server_service', autospec=True)


### PR DESCRIPTION
I have modified soft_mount function to call a new function 'mount' with the 'soft' argument. Otherwise - the function 'mount' works exactly like the past soft_mount, except that it gets an extra parameter - recovery_mode, which, by default, is set to hard - except when called from soft_mount.
I have changed the files calling this function (as nfs.mount instead of nfs.soft_mount) - NFSSR.py, test_NFSSR.py and test_nfs.py - to call a 'hard' mount by default.
My Python-foo is not too good, so I hope that I match the expected standards.