### PR TITLE
Changed default NFS mount option for non ISO SRs to 'hard'

### DIFF
--- a/drivers/NFSSR.py
+++ b/drivers/NFSSR.py
@@ -2,13 +2,13 @@
 #
 # Copyright (C) Citrix Systems Inc.
 #
-# This program is free software; you can redistribute it and/or modify 
-# it under the terms of the GNU Lesser General Public License as published 
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
 # by the Free Software Foundation; version 2.1 only.
 #
-# This program is distributed in the hope that it will be useful, 
-# but WITHOUT ANY WARRANTY; without even the implied warranty of 
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 # GNU Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public License
@@ -126,7 +126,7 @@ class NFSSR(FileSR.FileSR):
 
     def mount(self, mountpoint, remotepath, timeout=None, retrans=None):
         try:
-            nfs.soft_mount(
+            nfs.mount(
                     mountpoint, self.remoteserver, remotepath, self.transport,
                     useroptions=self.options, timeout=timeout,
                     nfsversion=self.nfsversion, retrans=retrans)

--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -47,6 +47,8 @@ SHOWMOUNT_BIN = "/usr/sbin/showmount"
 
 DEFAULT_NFSVERSION = '3'
 
+DEFAULT_RECOVERY_MODE = 'hard'
+
 NFS_VERSION = [
     'nfsversion', 'for type=nfs, NFS protocol version - 3, 4, 4.1']
 
@@ -54,6 +56,7 @@ NFS_SERVICE_WAIT = 30
 NFS_SERVICE_RETRY = 6
 
 class NfsException(Exception):
+
 
     def __init__(self, errstr):
         self.errstr = errstr
@@ -71,6 +74,7 @@ def check_server_tcp(server, nfsversion=DEFAULT_NFSVERSION):
     except util.CommandException, inst:
         raise NfsException("rpcinfo failed or timed out: return code %d" %
                            inst.code)
+
 
 def check_server_service(server):
     """Ensure NFS service is up and available on the remote server.
@@ -118,10 +122,20 @@ def validate_nfsversion(nfsversion):
 
 def soft_mount(mountpoint, remoteserver, remotepath, transport, useroptions='',
                timeout=None, nfsversion=DEFAULT_NFSVERSION, retrans=None):
+    """Backward compatibility for ISOSR.py and other NFS mount calls.
+    calls the 'real' mount function 'mount'
+    """
+    mount(mountpoint, remoteserver, remotepath, transport, useroptions='',
+               timeout=None, nfsversion=DEFAULT_NFSVERSION, recovery_mode='soft', retrans=None)
+
+
+def mount(mountpoint, remoteserver, remotepath, transport, useroptions='',
+               timeout=None, nfsversion=DEFAULT_NFSVERSION, recovery_mode=DEFAULT_RECOVERY_MODE, retrans=None):
     """Mount the remote NFS export at 'mountpoint'.
 
     The 'timeout' param here is in deciseconds (tenths of a second). See
     nfs(5) for details.
+    Default mount options are 'hard' except for explicit call to 'soft_mount' function
     """
     try:
         if not util.ioretry(lambda: util.isdir(mountpoint)):
@@ -132,7 +146,7 @@ def soft_mount(mountpoint, remoteserver, remotepath, transport, useroptions='',
 
 
     # Wait for NFS service to be available
-    try: 
+    try:
         if not check_server_service(remoteserver):
             raise util.CommandException(code=errno.EOPNOTSUPP,
                     reason="No NFS service on host")
@@ -143,11 +157,12 @@ def soft_mount(mountpoint, remoteserver, remotepath, transport, useroptions='',
     mountcommand = 'mount.nfs'
     if nfsversion == '4':
         mountcommand = 'mount.nfs4'
-        
+
     if nfsversion == '4.1':
         mountcommand = 'mount.nfs4'
 
-    options = "soft,proto=%s,vers=%s" % (
+    options = "%s,proto=%s,vers=%s" % (
+        recovery_mode,
         transport,
         nfsversion)
     options += ',acdirmin=0,acdirmax=0'

--- a/tests/test_NFSSR.py
+++ b/tests/test_NFSSR.py
@@ -67,12 +67,12 @@ class TestNFSSR(unittest.TestCase):
 
     @mock.patch('util.makedirs', autospec=True)
     @mock.patch('NFSSR.Lock', autospec=True)
-    @mock.patch('nfs.soft_mount', autospec=True)
+    @mock.patch('nfs.mount', autospec=True)
     @mock.patch('util._testHost', autospec=True)
     @mock.patch('nfs.check_server_tcp', autospec=True)
     @mock.patch('nfs.validate_nfsversion', autospec=True)
     def test_attach(self, validate_nfsversion, check_server_tcp, _testhost,
-                    soft_mount, Lock, makedirs):
+                    mount, Lock, makedirs):
         validate_nfsversion.return_value = "aNfsversionChanged"
         nfssr = self.create_nfssr(server='aServer', serverpath='/aServerpath',
                                   sr_uuid='UUID', useroptions='options')
@@ -81,7 +81,7 @@ class TestNFSSR(unittest.TestCase):
 
         check_server_tcp.assert_called_once_with('aServer',
                                                  'aNfsversionChanged')
-        soft_mount.assert_called_once_with('/var/run/sr-mount/UUID',
+        mount.assert_called_once_with('/var/run/sr-mount/UUID',
                                            'aServer',
                                            '/aServerpath/UUID',
                                            'tcp',

--- a/tests/test_nfs.py
+++ b/tests/test_nfs.py
@@ -76,13 +76,13 @@ class Test_nfs(unittest.TestCase):
 
     def get_soft_mount_pread(self, binary, vers):
         return ([binary, 'remoteserver:remotepath', 'mountpoint', '-o',
-                 'soft,proto=transport,vers=%s,acdirmin=0,acdirmax=0' % vers])
+                 'hard,proto=transport,vers=%s,acdirmin=0,acdirmax=0' % vers])
 
     @mock.patch('util.makedirs', autospec=True)
     @mock.patch('nfs.check_server_service', autospec=True)
     @mock.patch('util.pread', autospec=True)
     def test_soft_mount(self, pread, check_server_service, makedirs):
-        nfs.soft_mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
+        nfs.mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
                        timeout=None)
 
         check_server_service.assert_called_once_with('remoteserver')
@@ -94,7 +94,7 @@ class Test_nfs(unittest.TestCase):
     @mock.patch('util.pread', autospec=True)
     def test_soft_mount_nfsversion_3(self, pread, 
                                      check_server_service, makedirs):
-        nfs.soft_mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
+        nfs.mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
                        timeout=None, nfsversion='3')
 
         check_server_service.assert_called_once_with('remoteserver')
@@ -106,7 +106,7 @@ class Test_nfs(unittest.TestCase):
     @mock.patch('util.pread', autospec=True)
     def test_soft_mount_nfsversion_4(self, pread, 
                                      check_server_service, makedirs):
-        nfs.soft_mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
+        nfs.mount('mountpoint', 'remoteserver', 'remotepath', 'transport',
                        timeout=None, nfsversion='4')
 
         check_server_service.assert_called_once_with('remoteserver')


### PR DESCRIPTION
Modified soft_mount function to call a new function 'mount' with the 'soft' argument. Otherwise - the function 'mount' works exactly like the past soft_mount, except that it gets an extra parameter - 'recovery_mode', which, by default, is set to hard - except when called from soft_mount.
I have changed the files calling this function (as nfs.mount instead of nfs.soft_mount) - NFSSR.py, test_NFSSR.py and test_nfs.py - to call a 'hard' mount by default.

Some extended explanation:
NFS soft mount means that a short disconnection of NFS SR would be visible to the virtual machines. This is very good for storage recovery and handling of stale NFS mounts - because the application (in this case - the VM) get an IO error, and can abort. While this can be desirable for any regular NFS mount client, this is far from optimal for NFS shares used for VMs. It has been bugging me for a long while now, and I usually handle it by hacking the file nfs.py manually, enforcing hard mount. Short NFS disconnections can happen when an NFS cluster performs failover/takeover, when there is a small glitch in the network. With the current NFS soft mount option (which cannot be overridden even when using NFS SR arguments!) the NFS break "climbs" up to the virtual machines. In Windows a message saying "Delayed write failed" in the tray. In Linux it would, usually, cause the VM to switch filesystems to read-only mode, which would, in turn, require a reboot to resolve (emphasis on root filesystem).
The desired behaviour is 'hard' nfs recovery mount. If the NFS share becomes inaccessible, freeze all IO meant to get to it, until it becomes available again. It will still maintain crash consistency, which is imperative for VMs, and it might make life harder when you want to umount an SR (stale NFS are no fun), but it will reduce the impact of any network hang or cluster failover to zero.
I have been testing the manual hack on several XenServers and XCP-NG systems for a while now, and following a conversation I've had here, it is a good idea to bring this change to the mainstream. I have, purposely, left ISO mounts 'soft', because ISO shares can (and sometimes are), based on my experience, be placed on a more mobile systems (desktops, laptops even) - so I would not want failed mount there to block the system.

On another note - VMware mounts NFS hard. Always has. It works flawlessly there.