### PR TITLE
CA-337772: remove dead code handling qcow files.

### DIFF
--- a/drivers/VDI.py
+++ b/drivers/VDI.py
@@ -54,17 +54,7 @@ def VDIMetadataSize(type, virtualsize):
 
         # Segment bitmaps + Page align offsets
         size += (size_mb / 2) * 4096
-    elif type == 'qcow':
-        # Header + extended header
-        size = 46 + 17
-        size = util.roundup(512, size)
 
-        # L1 table
-        size += (size_mb / 2) * 8
-        size = util.roundup(4096, size)
-
-        # L2 tables
-        size += (size_mb / 2) * 4096
     return size
 
 class VDI(object):


### PR DESCRIPTION
This has a use before definition error in it anyway so can never
have been used and SonarQube marks this as a blocking issue.

Signed-off-by: Mark Syms <mark.syms@citrix.com>