### PR TITLE
Add HP(E) MSA x040 Devices

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -84,6 +84,19 @@ devices {
 		fast_io_fail_tmo	25
 	}
 	device {
+		vendor			"HP"
+		product			"MSA (1|2)040 SA(N|S)"
+		path_grouping_policy	"group_by_prio"
+		path_checker		"tur"
+		features		"0"
+		hardware_handler	"0"
+		prio			"alua"
+		failback		immediate
+		rr_weight		"uniform"
+		no_path_retry		18
+		rr_min_io		100
+	}
+	device {
 		vendor			"QNAP"
 		product			"iSCSI_Storage"
 		path_grouping_policy    "multibus"


### PR DESCRIPTION
Solution given back bei HP(E) MSA engineers, as XS/CH did not utilize mutlipath/alua properly.
Also refering to https://bugs.xenserver.org/browse/XSO-686
They said it's integrated in XS 7.3+ but I don't see it here in the code, also not in XCP-ng 8, which is based on this repo.

This configuration works properly here for some years. Load distribution and failovers tested.

Signed-off-by: Christof Giesers <c.giesers@giesers.de>