### PR TITLE
CA-333441 create directory for set-iscsi-initiator

### DIFF
--- a/scripts/set-iscsi-initiator
+++ b/scripts/set-iscsi-initiator
@@ -30,6 +30,8 @@ trap cleanup EXIT
 trap ecleanup INT
 trap ecleanup TERM
 
+mkdir -p /var/lock/sm/iscsiadm
+
 INITIATORFILE=/etc/iscsi/initiatorname.iscsi
 TMPFILE=$TMPDIR/initiatorname.iscsi
 
@@ -40,6 +42,7 @@ TMPFILE=$TMPDIR/initiatorname.iscsi
         if [ $? -eq 0 ]
         then
                 logger -p local2.err "set-iscsi-initiator active sessions so not updating"
+                echo "set-iscsi-initiator: there are active sessions so not updating" >&2
                 exit 1
         fi
 


### PR DESCRIPTION
It appears that the directory structure for the set-iscsi-initiator script
was missing. The directory /var/lock/sm/iscsiadm was created.

Signed-off-by: Gheorghe Burac <gheorghe.burac@citrix.com>