### PR TITLE
CA-349457: include the VDI uuid in the log when removing activating flag

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -1662,7 +1662,7 @@ class VDI(object):
             vdi_ref = self._session.xenapi.VDI.get_by_uuid(vdi_uuid)
             self._session.xenapi.VDI.remove_from_sm_config(
                 vdi_ref, 'activating')
-            util.SMlog("Removed activating flag")
+            util.SMlog("Removed activating flag from %s" % vdi_uuid)
 
 
         # Link result to backend/


### PR DESCRIPTION
Signed-off-by: Mark Syms <mark.syms@citrix.com>