### PR TITLE
XSI-915: Improve performance of LVHDoHBA operations by

### DIFF
--- a/drivers/LVHDoFCoESR.py
+++ b/drivers/LVHDoFCoESR.py
@@ -85,7 +85,6 @@ class LVHDoFCoESR(LVHDoHBASR.LVHDoHBASR):
             raise xs_errors.XenError('ConfigSCSIid')
 
         self.SCSIid = self.dconf['SCSIid']
-        self._pathrefresh(LVHDoFCoESR, load=False)
         LVHDSR.LVHDSR.load(self, sr_uuid)
 
     def vdi(self, uuid):

--- a/drivers/LVHDoHBASR.py
+++ b/drivers/LVHDoHBASR.py
@@ -107,14 +107,13 @@ class LVHDoHBASR(LVHDSR.LVHDSR):
                 raise xs_errors.XenError('ConfigSCSIid')
 
         self.SCSIid = self.dconf['SCSIid']
-        self._pathrefresh(LVHDoHBASR, load=False)
         LVHDSR.LVHDSR.load(self, sr_uuid)
 
     def create(self, sr_uuid, size):
         self.hbasr.attach(sr_uuid)
         if self.mpath == "true":
-            self.mpathmodule.refresh(self.SCSIid, 0)
-        self._pathrefresh(LVHDoHBASR)
+            self.mpathmodule.refresh(self.SCSIid,0)
+        self._pathrefresh()
         try:
             LVHDSR.LVHDSR.create(self, sr_uuid, size)
         finally:
@@ -132,7 +131,7 @@ class LVHDoHBASR(LVHDSR.LVHDSR):
             for file in os.listdir(path):
                 self.block_setscheduler('%s/%s' % (path, file))
 
-        self._pathrefresh(LVHDoHBASR)
+        self._pathrefresh()
         if not os.path.exists(self.dconf['device']):
             # Force a rescan on the bus
             self.hbasr._init_hbadict()
@@ -149,8 +148,8 @@ class LVHDoHBASR(LVHDSR.LVHDSR):
         if self.mpath == "true":
             if not os.path.exists(self.dconf['device']):
                 util.SMlog("@@@@@ path does not exists")
-                self.mpathmodule.refresh(self.SCSIid, 0)
-                self._pathrefresh(LVHDoHBASR)
+                self.mpathmodule.refresh(self.SCSIid,0)
+                self._pathrefresh()
                 self._setMultipathableFlag(SCSIid=self.SCSIid)
         LVHDSR.LVHDSR.scan(self, sr_uuid)
 
@@ -171,7 +170,7 @@ class LVHDoHBASR(LVHDSR.LVHDSR):
             self.mpathmodule.refresh(self.SCSIid, 0)
 
         try:
-            self._pathrefresh(LVHDoHBASR)
+            self._pathrefresh()
             result = LVHDSR.LVHDSR.probe(self)
             if self.mpath == "true":
                 self.mpathmodule.reset(self.SCSIid, explicit_unmap=True)

--- a/drivers/LVHDoISCSISR.py
+++ b/drivers/LVHDoISCSISR.py
@@ -338,7 +338,6 @@ class LVHDoISCSISR(LVHDSR.LVHDSR):
                     except:
                         raise xs_errors.XenError('ISCSILogout')
 
-        self._pathrefresh(LVHDoISCSISR, load=False)
 
         LVHDSR.LVHDSR.load(self, sr_uuid)
 
@@ -478,7 +477,7 @@ class LVHDoISCSISR(LVHDSR.LVHDSR):
                         continue
                 if not upgraded:
                     raise xs_errors.XenError('InvalidDev')
-            self._pathrefresh(LVHDoISCSISR)
+            self._pathrefresh()
             LVHDSR.LVHDSR.create(self, sr_uuid, size)
         except Exception as inst:
             self.iscsi.detach(sr_uuid)
@@ -519,7 +518,7 @@ class LVHDoISCSISR(LVHDSR.LVHDSR):
                 for a in self.iscsi.adapter:
                     scsiutil.rescan([self.iscsi.adapter[a]])
 
-            self._pathrefresh(LVHDoISCSISR)
+            self._pathrefresh()
             LVHDSR.LVHDSR.attach(self, sr_uuid)
         except Exception as inst:
             for i in self.iscsiSRs:
@@ -561,7 +560,7 @@ class LVHDoISCSISR(LVHDSR.LVHDSR):
         if not self.iscsi._attach_LUN_bySCSIid(self.SCSIid):
             util.SMlog("Unable to detect LUN")
             raise xs_errors.XenError('InvalidDev')
-        self._pathrefresh(LVHDoISCSISR)
+        self._pathrefresh()
         out = LVHDSR.LVHDSR.probe(self)
         self.iscsi.detach(self.uuid)
         return out

--- a/drivers/OCFSoHBASR.py
+++ b/drivers/OCFSoHBASR.py
@@ -77,14 +77,13 @@ class OCFSoHBASR(OCFSSR.OCFSSR):
             raise xs_errors.XenError('ConfigSCSIid')
 
         self.SCSIid = self.dconf['SCSIid']
-        self._pathrefresh(OCFSoHBASR, load=False)
         super(OCFSoHBASR, self).load(sr_uuid)
 
     def create(self, sr_uuid, size):
         self.hbasr.attach(sr_uuid)
         if self.mpath == "true":
             self.mpathmodule.refresh(self.SCSIid, 0)
-        self._pathrefresh(OCFSoHBASR)
+        self._pathrefresh()
         try:
             super(OCFSoHBASR, self).create(sr_uuid, size)
         finally:
@@ -102,7 +101,7 @@ class OCFSoHBASR(OCFSSR.OCFSSR):
             for file in os.listdir(path):
                 self.block_setscheduler('%s/%s' % (path, file))
 
-        self._pathrefresh(OCFSoHBASR)
+        self._pathrefresh()
         if not os.path.exists(self.dconf['device']):
             # Force a rescan on the bus
             self.hbasr._init_hbadict()
@@ -121,7 +120,7 @@ class OCFSoHBASR(OCFSSR.OCFSSR):
             if not os.path.exists(self.dconf['device']):
                 util.SMlog("%s path does not exists" % self.dconf['device'])
                 self.mpathmodule.refresh(self.SCSIid, 0)
-                self._pathrefresh(OCFSoHBASR)
+                self._pathrefresh()
                 self._setMultipathableFlag(SCSIid=self.SCSIid)
         super(OCFSoHBASR, self).scan(sr_uuid)
 
@@ -141,7 +140,7 @@ class OCFSoHBASR(OCFSSR.OCFSSR):
                 raise xs_errors.XenError('SRInUse')
             self.mpathmodule.refresh(self.SCSIid, 0)
         try:
-            self._pathrefresh(OCFSoHBASR)
+            self._pathrefresh()
             result = super(OCFSoHBASR, self).probe()
             if self.mpath == "true":
                 self.mpathmodule.reset(self.SCSIid, True)

--- a/drivers/OCFSoISCSISR.py
+++ b/drivers/OCFSoISCSISR.py
@@ -322,7 +322,6 @@ class OCFSoISCSISR(OCFSSR.OCFSSR):
                 except:
                     raise xs_errors.XenError('ISCSILogout')
 
-        self._pathrefresh(OCFSoISCSISR, load=False)
         OCFSSR.OCFSSR.load(self, sr_uuid)
 
     def print_LUNs_XML(self):
@@ -461,7 +460,7 @@ class OCFSoISCSISR(OCFSSR.OCFSSR):
                         continue
                 if not upgraded:
                     raise xs_errors.XenError('InvalidDev')
-            self._pathrefresh(OCFSoISCSISR)
+            self._pathrefresh()
             OCFSSR.OCFSSR.create(self, sr_uuid, size)
         except Exception as inst:
             self.iscsi.detach(sr_uuid)
@@ -499,7 +498,7 @@ class OCFSoISCSISR(OCFSSR.OCFSSR):
                 # Force a manual bus refresh
                 for a in self.iscsi.adapter:
                     scsiutil.rescan([self.iscsi.adapter[a]])
-            self._pathrefresh(OCFSoISCSISR)
+            self._pathrefresh()
             OCFSSR.OCFSSR.attach(self, sr_uuid)
         except Exception as inst:
             for i in self.iscsiSRs:
@@ -533,7 +532,7 @@ class OCFSoISCSISR(OCFSSR.OCFSSR):
         if not self.iscsi._attach_LUN_bySCSIid(self.SCSIid):
             util.SMlog("Unable to detect LUN")
             raise xs_errors.XenError('InvalidDev')
-        self._pathrefresh(OCFSoISCSISR)
+        self._pathrefresh()
         out = OCFSSR.OCFSSR.probe(self)
         self.iscsi.detach(self.uuid)
         return out

--- a/drivers/SR.py
+++ b/drivers/SR.py
@@ -489,11 +489,9 @@ class SR(object):
         else:
             self.mpathmodule.deactivate()
 
-    def _pathrefresh(self, obj, load=True):
+    def _pathrefresh(self):
         SCSIid = getattr(self, 'SCSIid')
         self.dconf['device'] = self.mpathmodule.path(SCSIid)
-        if load:
-            super(obj, self).load(self.uuid)
 
     def _setMultipathableFlag(self, SCSIid=''):
         try:

--- a/drivers/mpath_dmp.py
+++ b/drivers/mpath_dmp.py
@@ -113,7 +113,9 @@ def refresh(sid, npaths):
 def _is_valid_multipath_device(sid):
 
     # Check if device is already multipathed
-    (ret, stdout, stderr) = util.doexec(['/usr/sbin/multipath', '-ll', sid])
+    (ret, stdout, stderr) = util.doexec(['/usr/sbin/multipath', '-l', sid])
+    if not stdout + stderr:
+        (ret, stdout, stderr) = util.doexec(['/usr/sbin/multipath', '-ll', sid])
     if not stdout + stderr:
         (ret, stdout, stderr) = util.doexec(['/usr/sbin/multipath', '-a', sid])
         if ret < 0:

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1196,7 +1196,8 @@ def _containsVDIinuse(srobj):
 
 def isVDICommand(cmd):
     if cmd == None or cmd in ["vdi_attach", "vdi_detach",
-                              "vdi_activate", "vdi_deactivate"]:
+                              "vdi_activate", "vdi_deactivate",
+                              "vdi_epoch_begin", "vdi_epoch_end"]:
         return True
     else:
         return False

--- a/tests/test_mpath_dmp.py
+++ b/tests/test_mpath_dmp.py
@@ -51,18 +51,18 @@ class TestMpathDmp(unittest.TestCase):
         self.assertTrue(mpath_dmp._is_valid_multipath_device("fake_dev"))
 
         # Test 'multipath -a' failure
-        util_mod.doexec.side_effect = [(0, "", ""), (1, "out", "err")]
+        util_mod.doexec.side_effect = [(0, "", ""), (0, "", ""), (1, "out", "err")]
         self.assertFalse(mpath_dmp._is_valid_multipath_device("fake_dev"))
 
         # Test failure when device is not available
         mock_os.path.exists.return_value = False
-        util_mod.doexec.side_effect = [(0, "", ""), (0, "out", "err")]
+        util_mod.doexec.side_effect = [(0, "", ""), (0, "", ""), (0, "out", "err")]
         self.assertFalse(mpath_dmp._is_valid_multipath_device("fake_dev"))
 
         # Test 'multipath -c' with error and empty output
         mock_os.path.exists.return_value = True
         mock_os.listdir.side_effect = [['sdc']]
-        util_mod.doexec.side_effect = [(0, "", ""), (0, "out", "err"),
+        util_mod.doexec.side_effect = [(0, "", ""), (0, "", ""), (0, "out", "err"),
                                        (1, "", ""), OSError()]
         with self.assertRaises(SR.SROSError) as exc:
             mpath_dmp._is_valid_multipath_device("xx")
@@ -70,23 +70,23 @@ class TestMpathDmp(unittest.TestCase):
 
         # Test 'multipath -c' with error but some output
         mock_os.listdir.side_effect = [['sdc']]
-        util_mod.doexec.side_effect = [(0, "", ""), (0, "out", "err"),
+        util_mod.doexec.side_effect = [(0, "", ""), (0, "", ""), (0, "out", "err"),
                                        (1, "xx", "")]
         self.assertFalse(mpath_dmp._is_valid_multipath_device("fake_dev"))
 
         mock_os.listdir.side_effect = [['sdc']]
-        util_mod.doexec.side_effect = [(0, "", ""), (0, "out", "err"),
+        util_mod.doexec.side_effect = [(0, "", ""), (0, "", ""), (0, "out", "err"),
                                        (1, "xx", "yy")]
         self.assertFalse(mpath_dmp._is_valid_multipath_device("fake_dev"))
 
         mock_os.listdir.side_effect = [['sdc']]
-        util_mod.doexec.side_effect = [(0, "", ""), (0, "out", "err"),
+        util_mod.doexec.side_effect = [(0, "", ""), (0, "", ""), (0, "out", "err"),
                                        (1, "", "yy")]
         self.assertFalse(mpath_dmp._is_valid_multipath_device("fake_dev"))
 
         # Test when everything is fine
         mock_os.listdir.side_effect = [['sdc']]
-        util_mod.doexec.side_effect = [(0, "", ""), (0, "out", "err"),
+        util_mod.doexec.side_effect = [(0, "", ""), (0, "", ""), (0, "out", "err"),
                                        (0, "out", "err")]
         self.assertTrue(mpath_dmp._is_valid_multipath_device("fake_dev"))
 


### PR DESCRIPTION
	1) Reducing expensive calls to _pathfresh
	2) Use multipath with option "-l" and then falling back to using the more expensive "-ll"
	   only if first operation it fails.
	3) Add missing vdi_epoch operations to vdi operation list

Signed-off-by: ben sims <ben.sims@citrix.com>