### PR TITLE
Revert "CA-350871: Remove _lvmBugCleanup, superseded by locks"

### DIFF
--- a/drivers/lvmcache.py
+++ b/drivers/lvmcache.py
@@ -210,6 +210,7 @@ class LVMCache:
             self.lvs[lvName].active = False
         else:
             util.SMlog("LVMCache.deactivateNoRefcount: no LV %s" % lvName)
+            lvutil._lvmBugCleanup(path)
 
     @lazyInit
     def setHidden(self, lvName, hidden=True):

--- a/drivers/lvutil.py
+++ b/drivers/lvutil.py
@@ -573,6 +573,7 @@ def remove(path, config_param=None):
             if i >= LVM_FAIL_RETRIES - 1:
                 raise
             util.SMlog("*** lvremove failed on attempt #%d" % i)
+    _lvmBugCleanup(path)
 
 
 def _remove(path, config_param=None):
@@ -647,6 +648,7 @@ def deactivateNoRefcount(path):
             if i >= LVM_FAIL_RETRIES - 1:
                 raise
             util.SMlog("*** lvchange -an failed on attempt #%d" % i)
+    _lvmBugCleanup(path)
 
 
 def _deactivate(path):
@@ -690,6 +692,64 @@ def _checkActive(path):
             return True
 
     return False
+
+
+def _lvmBugCleanup(path):
+    # the device should not exist at this point. If it does, this was an LVM
+    # bug, and we manually clean up after LVM here
+    mapperDevice = path[5:].replace("-", "--").replace("/", "-")
+    mapperPath = "/dev/mapper/" + mapperDevice
+
+    nodeExists = False
+    cmd_st = [CMD_DMSETUP, "status", mapperDevice]
+    cmd_rm = [CMD_DMSETUP, "remove", mapperDevice]
+    cmd_rf = [CMD_DMSETUP, "remove", mapperDevice, "--force"]
+
+    try:
+        util.pread(cmd_st, expect_rc=1)
+    except util.CommandException as e:
+        if e.code == 0:
+            nodeExists = True
+
+    if not util.pathexists(mapperPath) and not nodeExists:
+        return
+
+    util.SMlog("_lvmBugCleanup: seeing dm file %s" % mapperPath)
+
+    # destroy the dm device
+    if nodeExists:
+        util.SMlog("_lvmBugCleanup: removing dm device %s" % mapperDevice)
+        for i in range(LVM_FAIL_RETRIES):
+            try:
+                util.pread2(cmd_rm)
+                break
+            except util.CommandException as e:
+                if i < LVM_FAIL_RETRIES - 1:
+                    util.SMlog("Failed on try %d, retrying" % i)
+                    try:
+                        util.pread(cmd_st, expect_rc=1)
+                        util.SMlog("_lvmBugCleanup: dm device {}"
+                                   " removed".format(mapperDevice)
+                                   )
+                        break
+                    except:
+                        cmd_rm = cmd_rf
+                        time.sleep(1)
+                else:
+                    # make sure the symlink is still there for consistency
+                    if not os.path.lexists(path):
+                        os.symlink(mapperPath, path)
+                        util.SMlog("_lvmBugCleanup: restored symlink %s" % path)
+                    raise e
+
+    if util.pathexists(mapperPath):
+        os.unlink(mapperPath)
+        util.SMlog("_lvmBugCleanup: deleted devmapper file %s" % mapperPath)
+
+    # delete the symlink
+    if os.path.lexists(path):
+        os.unlink(path)
+        util.SMlog("_lvmBugCleanup: deleted symlink %s" % path)
 
 
 # mdpath is of format /dev/VG-SR-UUID/MGT

--- a/tests/test_lvutil.py
+++ b/tests/test_lvutil.py
@@ -107,8 +107,9 @@ class TestRemove(unittest.TestCase):
 
         self.assertEquals([], lvsystem.get_logical_volumes_with_name('volume'))
 
+    @mock.patch('lvutil._lvmBugCleanup', autospec=True)
     @mock.patch('util.pread', autospec=True)
-    def test_remove_additional_config_param(self, mock_pread):
+    def test_remove_additional_config_param(self, mock_pread, _bugCleanup):
         lvutil.remove('VG_XenStorage-b3b18d06-b2ba-5b67-f098-3cdd5087a2a7/volume', config_param="blah")
         mock_pread.assert_called_once_with(
             [os.path.join(lvutil.LVM_BIN, lvutil.CMD_LVREMOVE)]


### PR DESCRIPTION
This reverts commit 87690110ee8f943083c04a51a611efa1b58a6c84.

Even with locks around each call to LVM commands we still get
failures on `lvchange -ay` when called immediately after an
`lvchange -an` on the same volume (as used in the remote host
refresh operation).

Signed-off-by: Mark Syms <mark.syms@citrix.com>