### PR TITLE
If no NFS ACLs provided, assume everyone

### DIFF
--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -205,7 +205,11 @@ def scan_exports(target):
         textnode = dom.createTextNode(target)
         subentry.appendChild(textnode)
 
-        (path, access) = val.split()
+        # Access is not always provided by showmount return
+        # If none is provided we need to assume "*"
+        array = val.split()
+        path = array[0]
+        access = array[1] if len(array) >= 2 else "*"
         subentry = dom.createElement("Path")
         entry.appendChild(subentry)
         textnode = dom.createTextNode(path)


### PR DESCRIPTION
Signed-off-by: BenjiReis <benjamin.reis@vates.fr>

Solves: https://github.com/xapi-project/sm/issues/511

As detailed in the issue, some devices (mostly QNAS devices) do not provide with NFS ACLs in `showmount -e` return, in this case we need to assume everyone is accepted, therefore `access = "*"`.