### PR TITLE
CA-352165: Check that 'device' exists in the dconf before using it, a…

### DIFF
--- a/drivers/LVHDoHBASR.py
+++ b/drivers/LVHDoHBASR.py
@@ -146,7 +146,7 @@ class LVHDoHBASR(LVHDSR.LVHDSR):
         # to point of the wrong device instead of dm-x. Running multipathing will
         # take care of this scenario.
         if self.mpath == "true":
-            if not os.path.exists(self.dconf['device']):
+            if 'device' not in self.dconf or not os.path.exists(self.dconf['device']):
                 util.SMlog("@@@@@ path does not exists")
                 self.mpathmodule.refresh(self.SCSIid, 0)
                 self._pathrefresh()

--- a/drivers/OCFSoHBASR.py
+++ b/drivers/OCFSoHBASR.py
@@ -117,7 +117,7 @@ class OCFSoHBASR(OCFSSR.OCFSSR):
         # to point of the wrong device instead of dm-x. Running multipathing
         # will take care of this scenario.
         if self.mpath == "true":
-            if not os.path.exists(self.dconf['device']):
+            if 'device' not in self.dconf or not os.path.exists(self.dconf['device']):
                 util.SMlog("%s path does not exists" % self.dconf['device'])
                 self.mpathmodule.refresh(self.SCSIid, 0)
                 self._pathrefresh()


### PR DESCRIPTION
This fixes the regressions found in the FCOE tests from XSI-915. 

I'm running this through the remaining FCOE to make sure nothing else is broken 