### PR TITLE
Fix regression added by XSI-915:

### DIFF
--- a/drivers/EXTSR.py
+++ b/drivers/EXTSR.py
@@ -64,6 +64,10 @@ class EXTSR(FileSR.FileSR):
         self.ops_exclusive = FileSR.OPS_EXCLUSIVE
         self.lock = Lock(vhdutil.LOCK_TYPE_SR, self.uuid)
         self.sr_vditype = SR.DEFAULT_TAP
+        if type(self) == EXTSR and (
+            'device' not in self.dconf or not self.dconf['device']
+        ):
+            raise xs_errors.XenError('ConfigDeviceMissing')
 
         self.path = os.path.join(SR.MOUNT_BASE, sr_uuid)
         self.vgname = EXT_PREFIX + sr_uuid

--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -147,6 +147,10 @@ class LVHDSR(SR.SR):
 
     def load(self, sr_uuid):
         self.ops_exclusive = OPS_EXCLUSIVE
+        if type(self) == LVHDSR and (
+            'device' not in self.dconf or not self.dconf['device']
+        ):
+            raise xs_errors.XenError('ConfigDeviceMissing')
 
         self.isMaster = False
         if 'SRmaster' in self.dconf and self.dconf['SRmaster'] == 'true':
@@ -205,19 +209,19 @@ class LVHDSR(SR.SR):
 
         for key in self.lvmCache.lvs.keys():
             # if the lvname has a uuid in it
-            type = None
+            vdi_type = None
             if contains_uuid_regex.search(key) != None:
                 if key.startswith(lvhdutil.LV_PREFIX[vhdutil.VDI_TYPE_VHD]):
-                    type = vhdutil.VDI_TYPE_VHD
-                    vdi = key[len(lvhdutil.LV_PREFIX[type]):]
+                    vdi_type = vhdutil.VDI_TYPE_VHD
+                    vdi = key[len(lvhdutil.LV_PREFIX[vdi_type]):]
                 elif key.startswith(lvhdutil.LV_PREFIX[vhdutil.VDI_TYPE_RAW]):
-                    type = vhdutil.VDI_TYPE_RAW
-                    vdi = key[len(lvhdutil.LV_PREFIX[type]):]
+                    vdi_type = vhdutil.VDI_TYPE_RAW
+                    vdi = key[len(lvhdutil.LV_PREFIX[vdi_type]):]
                 else:
                     continue
 
-            if type != None:
-                self.storageVDIs[vdi] = type
+            if vdi_type != None:
+                self.storageVDIs[vdi] = vdi_type
 
         # check if metadata volume exists
         try:


### PR DESCRIPTION
If device is missing during LVM/EXT SR creation we have this error:
```
Error code: SR_BACKEND_FAILURE_1200
Error parameters: , 'LVHDSR' object has no attribute 'root',
```

With this fix we retrieve a more explicit message:
```
Error code: SR_BACKEND_FAILURE_90
Error parameters: , The request is missing the device parameter,
```

Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>