### PR TITLE
CA-356645: use "self.session is None" not "self.session == None"

### DIFF
--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -281,7 +281,7 @@ class XAPI:
     def __init__(self, session, srUuid):
         self.sessionPrivate = False
         self.session = session
-        if self.session == None:
+        if self.session is None:
             self.session = self.getSession()
             self.sessionPrivate = True
         self._srRef = self.session.xenapi.SR.get_by_uuid(srUuid)


### PR DESCRIPTION
Python runtime converts use of == to a call to "__eq__" on the object
and this is not implemented by the Xapi session XMLRPC proxy. After
https://github.com/xapi-project/xen-api/pull/4464 this code causes an
exception.

Signed-off-by: Mark Syms <mark.syms@citrix.com>