### PR TITLE
CA-334762/CA-356983: fix VDI import for storage driver domains

### DIFF
--- a/udev/58-xapi.rules
+++ b/udev/58-xapi.rules
@@ -3,6 +3,8 @@
 # Skip block devices - no networks in here
 SUBSYSTEM!="block", GOTO="end_xapi"
 
+ACTION=="add|change", KERNEL=="xvd*", GOTO="ignore_device"
+
 # srX are not partitions, go check if it's a cdrom. handle remove specially.
 ACTION=="remove", KERNEL=="sr[0-9]", GOTO="usb_symlink"
 KERNEL=="sr[0-9]", GOTO="maybe_cdrom"
@@ -44,6 +46,28 @@ ACTION=="add|change", SYMLINK+="xapi/block/%k"
 
 ACTION=="add", RUN+="/bin/sh -c '/opt/xensource/libexec/local-device-change %k 2>&1 >/dev/null&'"
 ACTION=="remove", RUN+="/bin/sh -c '/opt/xensource/libexec/local-device-change %k 2>&1 >/dev/null&'"
+
+GOTO="end_xapi"
+
+# Handle VDIs plugged into Dom0 here: #############################################
+LABEL="ignore_device"
+
+# Do not let udev access them: it would prevent unplugging during VDI import
+# To avoid patching other udev rule files we set env vars to skip processing rules
+
+# from dm_disable in 10-dm.rules
+# will also disable 65-md-incremental.rules processing
+ENV{DM_UDEV_DISABLE_SUBSYSTEM_RULES_FLAG}="1"
+ENV{DM_UDEV_DISABLE_DISK_RULES_FLAG}="1"
+ENV{DM_UDEV_DISABLE_OTHER_RULES_FLAG}="1"
+OPTIONS:="nowatch"
+
+# prevent 60-persistent-storage.rules processing
+# depends on backported env flag in systemd
+ENV{UDEV_DISABLE_PERSISTENT_STORAGE_RULES_FLAG}="1"
+
+# prevent 62-multipath.rules processing
+ENV{nompath}="1"
 
 GOTO="end_xapi"
 

--- a/udev/58-xapi.rules
+++ b/udev/58-xapi.rules
@@ -3,7 +3,7 @@
 # Skip block devices - no networks in here
 SUBSYSTEM!="block", GOTO="end_xapi"
 
-ACTION=="add|change", KERNEL=="xvd*", GOTO="ignore_device"
+ACTION=="add|change", KERNEL=="xvd*|td*|nbd*", GOTO="ignore_device"
 
 # srX are not partitions, go check if it's a cdrom. handle remove specially.
 ACTION=="remove", KERNEL=="sr[0-9]", GOTO="usb_symlink"

--- a/udev/65-multipath.rules
+++ b/udev/65-multipath.rules
@@ -2,6 +2,9 @@ SUBSYSTEM!="block", GOTO="end_mpath"
 KERNEL=="nbd*", GOTO="end_mpath"
 KERNEL=="td[a-z]*", GOTO="end_mpath"
 
+# like in 62-multipath.rules
+ENV{nompath}=="?*", GOTO="end_mpath"
+
 IMPORT{db}="DM_MULTIPATH_DEVICE_PATH"
 ACTION=="add",  ENV{DM_MULTIPATH_DEVICE_PATH}=="1", GOTO="count_mpath"
 ACTION=="remove", ENV{DM_MULTIPATH_DEVICE_PATH}=="1",  GOTO="count_mpath"

--- a/udev/65-multipath.rules
+++ b/udev/65-multipath.rules
@@ -1,6 +1,4 @@
 SUBSYSTEM!="block", GOTO="end_mpath"
-KERNEL=="nbd*", GOTO="end_mpath"
-KERNEL=="td[a-z]*", GOTO="end_mpath"
 
 # like in 62-multipath.rules
 ENV{nompath}=="?*", GOTO="end_mpath"


### PR DESCRIPTION
Details explained in commit messages: udev is launching various commands when xvd* devices are plugged into Dom0 and this prevents unplug with a device in use error. Plug/unplug is needed for VDI import to work.

Tested with a storage driver domain, and also added some cleanups for td/nbd (there were udev rules to ignore these devices, but not everywhere, e.g. I was still getting some multipath commands launched for them).
Still need to test the td/nbd side of changes, hence the draft PR.