### PR TITLE
CA-352880: when deleting an HBA SR remove the kernel devices

### DIFF
--- a/drivers/LVHDoHBASR.py
+++ b/drivers/LVHDoHBASR.py
@@ -195,6 +195,17 @@ class LVHDoHBASR(LVHDSR.LVHDSR):
             except:
                 pass
 
+    def _remove_device_nodes(self):
+        """
+        Remove the kernel device nodes
+        """
+        nodes = glob.glob('/dev/disk/by-scsid/%s/*' % self.SCSIid)
+        util.SMlog('Remove_nodes, nodes are %s' % nodes)
+        for node in nodes:
+            with open('/sys/block/%s/device/delete' %
+                      (os.path.basename(node)), 'w') as f:
+                f.write('1\n')
+
     def delete(self, sr_uuid):
         self._pathrefresh(LVHDoHBASR)
         try:
@@ -202,6 +213,7 @@ class LVHDoHBASR(LVHDSR.LVHDSR):
         finally:
             if self.mpath == "true":
                 self.mpathmodule.reset(self.SCSIid, explicit_unmap=True)
+            self._remove_device_nodes()
 
     def vdi(self, uuid):
         return LVHDoHBAVDI(self, uuid)

--- a/drivers/LVHDoHBASR.py
+++ b/drivers/LVHDoHBASR.py
@@ -107,7 +107,7 @@ class LVHDoHBASR(LVHDSR.LVHDSR):
                 raise xs_errors.XenError('ConfigSCSIid')
 
         self.SCSIid = self.dconf['SCSIid']
-        LVHDSR.LVHDSR.load(self, sr_uuid)
+        super(LVHDoHBASR, self).load(sr_uuid)
 
     def create(self, sr_uuid, size):
         self.hbasr.attach(sr_uuid)


### PR DESCRIPTION
If this is not done, in particular with a Fibre Channel SR where
the LUN mapping may be subsequently removed kernel errors can be
encnountered until the host is rebooted if another HBA SR is
scanned.

e.g.

Mar 23 13:43:10 <host> kernel: [446324.856765] sd 1:0:2:0: [sdd] tag#0 FAILED Result: hostbyte=DID_OK driverbyte=DRIVER_SENSE
Mar 23 13:43:10 <host> kernel: [446324.856775] sd 1:0:2:0: [sdd] tag#0 Sense Key : Illegal Request [current]
Mar 23 13:43:10 <host> kernel: [446324.856778] sd 1:0:2:0: [sdd] tag#0 Add. Sense: Logical unit not supported
Mar 23 13:43:10 <host> kernel: [446324.856784] sd 1:0:2:0: [sdd] tag#0 CDB: Read(10) 28 00 00 00 00 00 00 00 80 00

If the host is rebooted between the SR being deleted and the LUN
mapping being removed then this error will recur until the host
is rebooted again.

Signed-off-by: Mark Syms <mark.syms@citrix.com>