### PR TITLE
CP-38283: Support explicit NFS 4.0 version choice

### DIFF
--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -112,7 +112,7 @@ def validate_nfsversion(nfsversion):
     if not nfsversion:
         nfsversion = DEFAULT_NFSVERSION
     else:
-        if nfsversion not in ['3', '4', '4.0', '4.1']:
+        if not (nfsversion == '3' or nfsversion.startswith('4')):
             raise NfsException("Invalid nfsversion.")
     return nfsversion
 

--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -47,7 +47,7 @@ SHOWMOUNT_BIN = "/usr/sbin/showmount"
 DEFAULT_NFSVERSION = '3'
 
 NFS_VERSION = [
-    'nfsversion', 'for type=nfs, NFS protocol version - 3, 4, 4.1']
+    'nfsversion', 'for type=nfs, NFS protocol version - 3, 4, 4.0, 4.1']
 
 NFS_SERVICE_WAIT = 30
 NFS_SERVICE_RETRY = 6
@@ -112,7 +112,7 @@ def validate_nfsversion(nfsversion):
     if not nfsversion:
         nfsversion = DEFAULT_NFSVERSION
     else:
-        if nfsversion not in ['3', '4', '4.1']:
+        if nfsversion not in ['3', '4', '4.0', '4.1']:
             raise NfsException("Invalid nfsversion.")
     return nfsversion
 
@@ -142,11 +142,6 @@ def soft_mount(mountpoint, remoteserver, remotepath, transport, useroptions='',
                            % remoteserver)
 
     mountcommand = 'mount.nfs'
-    if nfsversion == '4':
-        mountcommand = 'mount.nfs4'
-
-    if nfsversion == '4.1':
-        mountcommand = 'mount.nfs4'
 
     options = "soft,proto=%s,vers=%s" % (
         transport,

--- a/tests/test_nfs.py
+++ b/tests/test_nfs.py
@@ -133,7 +133,7 @@ class Test_nfs(unittest.TestCase):
                        timeout=None, nfsversion='4')
 
         check_server_service.assert_called_once_with('remoteserver')
-        pread.assert_called_with(self.get_soft_mount_pread('mount.nfs4',
+        pread.assert_called_with(self.get_soft_mount_pread('mount.nfs',
                                                                 '4'))
 
     def test_validate_nfsversion_invalid(self):
@@ -151,7 +151,7 @@ class Test_nfs(unittest.TestCase):
             self.assertEquals(nfs.validate_nfsversion(thenfsversion), '3')
 
     def test_validate_nfsversion_valid(self):
-        for thenfsversion in ['3', '4', '4.1']:
+        for thenfsversion in ['3', '4', '4.0', '4.1']:
             self.assertEquals(nfs.validate_nfsversion(thenfsversion),
                               thenfsversion)
 

--- a/tests/test_nfs.py
+++ b/tests/test_nfs.py
@@ -151,7 +151,7 @@ class Test_nfs(unittest.TestCase):
             self.assertEquals(nfs.validate_nfsversion(thenfsversion), '3')
 
     def test_validate_nfsversion_valid(self):
-        for thenfsversion in ['3', '4', '4.0', '4.1']:
+        for thenfsversion in ['3', '4', '4.0', '4.1', '4.2']:
             self.assertEquals(nfs.validate_nfsversion(thenfsversion),
                               thenfsversion)
 


### PR DESCRIPTION
Setting nfsversion=4 uses either 4.0 or 4.1, depending what is
available.

It is already possible to explicitly force 4.1, add similar support for
4.0.

Explicitly choosing 4.0 can be important when trying to
diagnose potential performance regressions due to NFS versions / NFS
server changes.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>