### PR TITLE
CA-359621: fix regression in error handler

### DIFF
--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1393,7 +1393,8 @@ fistpoint = FistPoint(["LVHDRT_finding_a_suitable_pair",
                         "xenrt_default_vdi_type_legacy",
                         "blktap_activate_inject_failure",
                         "blktap_activate_error_handling",
-                        GCPAUSE_FISTPOINT])
+                        GCPAUSE_FISTPOINT,
+                        "cleanup_coalesceVHD_inject_failure"])
 
 
 def set_dirty(session, sr):


### PR DESCRIPTION
Parent returned from vhdutil.getParent is the path of the parent not a
VDI object. Lookup the VDI before dereferencing the raw attribute. Add
fault injection fist point to allow for testing.

Signed-off-by: Mark Syms <mark.syms@citrix.com>