### PR TITLE
QNAP product attribute is incorrect

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -85,7 +85,7 @@ devices {
 	}
 	device {
 		vendor			"QNAP"
-		product			"iSCSI_Storage"
+		product			"iSCSI Storage"
 		path_grouping_policy    "multibus"
 		path_selector	        "round-robin 0"
 		path_checker	        readsector0


### PR DESCRIPTION
Hello,

I found an incorrect QNAP entry in multipath.conf.
The product attribute was "iSCSI_Storage", but the actual QNAP product attribute was "iSCSI Storage". Underscores should be spaces.

I suggested writing 2 blocks of underscore and space in the forum below.
Please check the forum below for details.
https://xcp-ng.org/forum/topic/5194/multipath-conf-is-incorrect

I was suggested by forum users to give feedback to the fork source.

I use multipathing with iSCSI in QNAP.
Because of the different multipath speeds, I had to set a fixed priority.
I noticed this mistake with the multipath -ll command and posted.