### PR TITLE
Fix timeout_call function

### DIFF
--- a/drivers/util.py
+++ b/drivers/util.py
@@ -886,10 +886,9 @@ def timeout_call(timeoutseconds, function, *arguments):
     signal.signal(signal.SIGALRM, handler)
     signal.alarm(timeoutseconds)
     try:
-        function( * arguments)
-    except:
+        function(*arguments)
+    finally:
         signal.alarm(0)
-        raise
 
 
 def _incr_iscsiSR_refcount(targetIQN, uuid):

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -886,7 +886,7 @@ def timeout_call(timeoutseconds, function, *arguments):
     signal.signal(signal.SIGALRM, handler)
     signal.alarm(timeoutseconds)
     try:
-        function(*arguments)
+        return function(*arguments)
     finally:
         signal.alarm(0)
 


### PR DESCRIPTION
Ensure alarm is correctly reset in case of success after user function execution.
Otherwise the SIGALRM signal can be emitted after the execution of the given function.