### PR TITLE
CA-365359: cope with on_slave.is_open passing server=None

### DIFF
--- a/drivers/NFSSR.py
+++ b/drivers/NFSSR.py
@@ -259,6 +259,10 @@ class NFSSR(FileSR.SharedFileSR):
 
     def set_transport(self):
         self.transport = DEFAULT_TRANSPORT
+        if self.remoteserver is None:
+            # CA-365359: on_slave.is_open sends a dconf with {"server": None}
+            return
+
         use_ipv6 = util.get_ip_address_family(self.remoteserver) == 6
         if use_ipv6:
             self.transport = 'tcp6'

--- a/tests/test_NFSSR.py
+++ b/tests/test_NFSSR.py
@@ -95,3 +95,12 @@ class TestNFSSR(unittest.TestCase):
     def test_load_ipv6(self, mock_lock):
         nfssr = self.create_nfssr(server='::1')
         self.assertEqual(nfssr.transport, 'tcp6')
+
+    @mock.patch('NFSSR.Lock', autospec=True)
+    def test_load_no_server(self, mock_lock):
+        """
+        As called by on_slave.is_open
+        """
+        nfssr = self.create_nfssr(server=None)
+
+        self.assertIsNotNone(nfssr)


### PR DESCRIPTION
Signed-off-by: Mark Syms <mark.syms@citrix.com>