### PR TITLE
Raise explicit error in case of NFS mount failure

### DIFF
--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -364,6 +364,8 @@ class ISOSR(SR.SR):
             else:
                 raise xs_errors.XenError(
                     'ISOMountFailure', opterr=inst.reason)
+        except nfs.NfsException as e:
+            raise xs_errors.XenError('ISOMountFailure', opterr=str(e.errstr))
 
         # Check the iso_path is accessible
         if not self._checkmount():

--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -135,10 +135,12 @@ def soft_mount(mountpoint, remoteserver, remotepath, transport, useroptions='',
     # Wait for NFS service to be available
     try:
         if not check_server_service(remoteserver):
-            raise util.CommandException(code=errno.EOPNOTSUPP,
-                    reason="No NFS service on host")
+            raise util.CommandException(
+                code=errno.EOPNOTSUPP,
+                reason='No NFS service on server: `%s`' % remoteserver
+            )
     except util.CommandException as inst:
-        raise NfsException("Failed to detect NFS service on server %s"
+        raise NfsException("Failed to detect NFS service on server `%s`"
                            % remoteserver)
 
     mountcommand = 'mount.nfs'
@@ -165,7 +167,11 @@ def soft_mount(mountpoint, remoteserver, remotepath, transport, useroptions='',
                      errlist=[errno.EPIPE, errno.EIO],
                      maxretry=2, nofail=True)
     except util.CommandException as inst:
-        raise NfsException("mount failed with return code %d" % inst.code)
+        raise NfsException(
+            "mount failed on server `%s` with return code %d" % (
+                remoteserver, inst.code
+            )
+        )
 
 
 def unmount(mountpoint, rmmountpoint):


### PR DESCRIPTION
During creation of ISOSR with NFS params, we can get a generic error with this command line:

```
xe sr-create host-uuid=<uuid> content-type=iso type=iso name-label=<loc> device-config:location=<invalid_server_path>
```

Before this patch the returned error was:

```
Error code: SR_BACKEND_FAILURE_1200
Error parameters: , ,
```

After:

```
Error code: SR_BACKEND_FAILURE_222
Error parameters: , Could not mount the directory specified in Device Configuration [opterr=mount failed with return code 32],
```

Signed-off-by: Ronan Abhamon <ronan.abhamon@vates.fr>