### PR TITLE
Added Dell ME4 multipath config

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -41,6 +41,17 @@ devices {
 		no_path_retry		30
 	}
 	device {
+		vendor			"DellEMC"
+		product			"ME4"
+		path_grouping_policy	"group_by_prio"
+		path_checker		"tur"
+		hardware_handler	"1 alua"
+		prio			"alua"
+		failback		immediate
+		rr_weight		"uniform"
+		path_selector		"service-time 0"
+	}
+	device {
 		vendor			"DGC"
 		product			".*"
 		detect_prio		yes


### PR DESCRIPTION
Hi all,

we are using some Dell ME4 iSCSI-NAS Devices. Would be great to have a good multipath-config in place by default. For details: see https://downloads.dell.com/manuals/common/powervault-me4-series-linux-3924-bp-l_en-us.pdf

Regards,

Ulrich Göttlich