### PR TITLE
CA-368769: extend the timeout on tap-ctl close

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -404,7 +404,7 @@ class TapCtl(object):
 
     @classmethod
     def close(cls, pid, minor, force=False):
-        args = ["close", "-p", pid, "-m", minor, "-t", "30"]
+        args = ["close", "-p", pid, "-m", minor, "-t", "120"]
         if force:
             args += ["-f"]
         cls._pread(args)

--- a/tests/test_blktap2.py
+++ b/tests/test_blktap2.py
@@ -542,7 +542,7 @@ class TestTapCtl(unittest.TestCase):
         self.assertIn('-p 22127', proc_args)
         self.assertIn('-m 2', proc_args)
         # Close should have a timeout
-        self.assertIn('-t 30', proc_args)
+        self.assertIn('-t 120', proc_args)
         # Not forced
         self.assertNotIn('-f', proc_args)
 
@@ -563,7 +563,7 @@ class TestTapCtl(unittest.TestCase):
         self.assertIn('-p 22127', proc_args)
         self.assertIn('-m 2', proc_args)
         # Close should have a timeout
-        self.assertIn('-t 30', proc_args)
+        self.assertIn('-t 120', proc_args)
         # Forced
         self.assertIn('-f', proc_args)
 


### PR DESCRIPTION
In XSI-620 the storage manager scripts were blocked by a tapdisk
process which was hung totally and blocked for over an hour. A
timout was added to this close operation to unblock things but the
timeout is only on the IPC and so breaks the IPC link if the timeout
is reached. Which is fine if the remote process is entirely wedged,
however when a close is requested and there are pending IO requests,
possibly during a migrate, the close operation can take significantly
longer than the currently permitted 30 seconds, 50 seconds observed
in failing tests. So, extend the timeout such that this scenario
should be handled successfully whilst not reintroducing the issues
seen in XSI-620.

Signed-off-by: Mark Syms <mark.syms@citrix.com>