### PR TITLE
CA-369395: default multipath handle to dmp if not set

### DIFF
--- a/drivers/SR.py
+++ b/drivers/SR.py
@@ -487,7 +487,7 @@ class SR(object):
             else:
                 hconf = self.session.xenapi.host.get_other_config(self.host_ref)
                 self.mpath = hconf['multipathing']
-                self.mpathhandle = hconf['multipathhandle']
+                self.mpathhandle = hconf.get('multipathhandle', 'dmp')
 
             if self.mpath != "true":
                 self.mpath = "false"


### PR DESCRIPTION
If
```
xe host-param-set multipathing=true uuid=<uuid>
```
is used it doesn't set the multipathhandle (which XenCenter does do), but as we only support Device Mapper Multipath mutipathing now we can set that as a default if multipathing is enabled in this way.

This doesn't change the other path of reading from `dconf` which is a deprecated mechanism anyway as that requires `multipathhandle` to be supplied in order to activate the path.