### PR TITLE
CA 370037: Fix error handling in NFS SR Create

### DIFF
--- a/drivers/NFSSR.py
+++ b/drivers/NFSSR.py
@@ -207,7 +207,7 @@ class NFSSR(FileSR.SharedFileSR):
                 os.rmdir(self.path)
             except:
                 pass
-            raise exn
+            raise
 
         if not self.nosubdir:
             newpath = os.path.join(self.path, sr_uuid)

--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -278,7 +278,7 @@ def get_supported_nfs_versions(server):
         return list(cv & valid_versions)
     except:
         util.SMlog("Unable to obtain list of valid nfs versions")
-        raise NfsException('Failed to read supported NFS version from server' %
+        raise NfsException('Failed to read supported NFS version from server %s' %
                            (server))
 
 

--- a/tests/test_nfs.py
+++ b/tests/test_nfs.py
@@ -20,6 +20,15 @@ class Test_nfs(unittest.TestCase):
 
         pread.assert_called_once_with(['/usr/sbin/rpcinfo', '-s', 'aServer'], quiet=False)
 
+    @mock.patch('util.pread', autospec=True)
+    def test_check_server_tcp_nfsversion_error(self, pread):
+        pread.side_effect = util.CommandException
+
+        with self.assertRaises(nfs.NfsException):
+            nfs.check_server_tcp('aServer', 'aNfsversion')
+
+        pread.assert_called_once_with(['/usr/sbin/rpcinfo', '-s', 'aServer'], quiet=False)
+
     @mock.patch('time.sleep', autospec=True)
     # Can't use autospec due to http://bugs.python.org/issue17826
     @mock.patch('util.pread')


### PR DESCRIPTION
If an error is thrown from get_supported_nfs_versions the error path mishandles the error and ends up in the catch all error handling having also dropped all the original error context so that the logs are useless. Fix this and cover the code paths with unit tests.