### PR TITLE
Tidy the unit test runner script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Test
         run: |
           PYTHONPATH=./drivers pylint --rcfile=tests/pylintrc ./drivers/*.py
-          PYTHONPATH=./drivers/ coverage run --branch --source='./drivers,./tests' $(command -v nosetests) -c .noserc tests
+          PYTHONPATH=./drivers/ coverage run --branch --source='./drivers,./tests' -m unittest discover -s tests -p "*.py" -v
           coverage report --include='./*'

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,3 @@
-nose
 mock==1.0.1
 xenapi
 coverage


### PR DESCRIPTION
* shellcheck
* direct check result of coverage for test code
* use native pyhon unit test runner not nosetests
* remove virtual env start as it's not terribly useful on modern OSes (until Python 3 happens)

Signed-off-by: Mark Syms <mark.syms@citrix.com>