### PR TITLE
CA-370696 Do not attempt to validate device or NFS server paths

### DIFF
--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -453,7 +453,7 @@ class LVHDSR(SR.SR):
             return scsiutil.refresh_lun_size_by_SCSIid(getattr(self, 'SCSIid'))
         else:
             # LVHDSR
-            devices = self.root.split(',')
+            devices = self.dconf['device'].split(',')
             scsiutil.refreshdev(devices)
             return True
 
@@ -466,7 +466,7 @@ class LVHDSR(SR.SR):
         currentvgsize = lvutil._getVGstats(self.vgname)['physical_size']
         # We are comparing PV- with VG-sizes that are aligned. Need a threshold
         resizethreshold = 100 * 1024 * 1024  # 100MB
-        devices = self.root.split(',')
+        devices = self.dconf['device'].split(',')
         totaldevicesize = 0
         for device in devices:
             totaldevicesize = totaldevicesize + scsiutil.getsize(device)
@@ -495,19 +495,19 @@ class LVHDSR(SR.SR):
             raise xs_errors.XenError('SRExists')
 
         # Check none of the devices already in use by other PBDs
-        if util.test_hostPBD_devs(self.session, uuid, self.root):
+        if util.test_hostPBD_devs(self.session, uuid, self.dconf['device']):
             raise xs_errors.XenError('SRInUse')
 
         # Check serial number entry in SR records
-        for dev in self.root.split(','):
+        for dev in self.dconf['device'].split(','):
             if util.test_scsiserial(self.session, dev):
                 raise xs_errors.XenError('SRInUse')
 
-        lvutil.createVG(self.root, self.vgname)
+        lvutil.createVG(self.dconf['device'], self.vgname)
 
         #Update serial number string
         scsiutil.add_serial_record(self.session, self.sr_ref, \
-                scsiutil.devlist_to_serialstring(self.root.split(',')))
+                scsiutil.devlist_to_serialstring(self.dconf['device'].split(',')))
 
         # since this is an SR.create turn off legacy mode
         self.session.xenapi.SR.add_to_sm_config(self.sr_ref, \
@@ -563,7 +563,7 @@ class LVHDSR(SR.SR):
             raise Exception("LVHDSR delete failed, please refer to the log " \
                             "for details.")
 
-        lvutil.removeVG(self.root, self.vgname)
+        lvutil.removeVG(self.dconf['device'], self.vgname)
         self._cleanup()
 
     def attach(self, uuid):
@@ -586,7 +586,7 @@ class LVHDSR(SR.SR):
             #Update SCSIid string
             util.SMlog("Calling devlist_to_serial")
             scsiutil.add_serial_record(self.session, self.sr_ref, \
-                    scsiutil.devlist_to_serialstring(self.root.split(',')))
+                    scsiutil.devlist_to_serialstring(self.dconf['device'].split(',')))
 
         # Test Legacy Mode Flag and update if VHD volumes exist
         if self.isMaster and self.legacyMode:
@@ -599,7 +599,7 @@ class LVHDSR(SR.SR):
                     break
 
         # Set the block scheduler
-        for dev in self.root.split(','):
+        for dev in self.dconf['device'].split(','):
             self.block_setscheduler(dev)
 
     def detach(self, uuid):
@@ -843,7 +843,7 @@ class LVHDSR(SR.SR):
     @deviceCheck
     def probe(self):
         return lvutil.srlist_toxml(
-                lvutil.scan_srlist(lvhdutil.VG_PREFIX, self.root),
+                lvutil.scan_srlist(lvhdutil.VG_PREFIX, self.dconf['device']),
                 lvhdutil.VG_PREFIX,
                 ('metadata' in self.srcmd.params['sr_sm_config'] and \
                  self.srcmd.params['sr_sm_config']['metadata'] == 'true'))

--- a/drivers/NFSSR.py
+++ b/drivers/NFSSR.py
@@ -108,9 +108,6 @@ class NFSSR(FileSR.SharedFileSR):
                 except:
                     pass
             raise xs_errors.XenError('ConfigServerPathMissing')
-        if not self._isvalidpathstring(self.dconf['serverpath']):
-            raise xs_errors.XenError('ConfigServerPathBad', \
-                  opterr='serverpath is %s' % self.dconf['serverpath'])
 
     def check_server(self):
         try:

--- a/drivers/SR.py
+++ b/drivers/SR.py
@@ -166,7 +166,6 @@ class SR(object):
         self.driver_config = {}
 
         self.load(sr_uuid)
-        self.checkroot()
 
     @staticmethod
     def from_uuid(session, sr_uuid):
@@ -456,21 +455,6 @@ class SR(object):
                     taglist[node.nodeName] += n.data
         return taglist
 
-    def _isvalidpathstring(self, path):
-        if not path.startswith("/"):
-            return False
-        l = self._splitstring(path)
-        for char in l:
-            if char.isalpha():
-                continue
-            elif char.isdigit():
-                continue
-            elif char in ['/', '-', '_', '.', ':']:
-                continue
-            else:
-                return False
-        return True
-
     def _splitstring(self, str):
         elementlist = []
         for i in range(0, len(str)):
@@ -507,19 +491,9 @@ class SR(object):
         else:
             self.mpathmodule.deactivate()
 
-    def checkroot(self):
-        if 'device' in self.dconf:
-            self.root = self.dconf['device']
-            if self.root:
-                for dev in self.root.split(','):
-                    if not self._isvalidpathstring(dev):
-                        raise xs_errors.XenError('ConfigDeviceInvalid', \
-                              opterr='path is %s' % dev)
-
     def _pathrefresh(self, obj):
         SCSIid = getattr(self, 'SCSIid')
         self.dconf['device'] = self.mpathmodule.path(SCSIid)
-        self.checkroot()
         super(obj, self).load(self.uuid)
 
     def _setMultipathableFlag(self, SCSIid=''):

--- a/tests/test_SR.py
+++ b/tests/test_SR.py
@@ -34,25 +34,6 @@ class TestSR(unittest.TestCase):
             srcmd.params.update(cmd_params)
         return SR.SR(srcmd, "some SR UUID")
 
-    def test_checkroot_no_device(self):
-        sr1 = self.create_SR("sr_create", {'ISCSIid': '12333423'})
-        sr1.checkroot()
-
-    @mock.patch('SR.SR._isvalidpathstring', autospec=True)
-    def test_checkroot_validdevices(self, mock_validpath):
-        sr1 = self.create_SR("sr_create",
-                             {'device': '/dev/sdb,/dev/sdc/,/dev/sdz'})
-        mock_validpath.side_effect = iter([True, True, True])
-        sr1.checkroot()
-
-    @mock.patch('FileSR.xs_errors.XML_DEFS', "drivers/XE_SR_ERRORCODES.xml")
-    @mock.patch('SR.SR._isvalidpathstring', autospec=True)
-    def test_checkroot_exceptionraised(self, mock_validpath):
-        sr1 = self.create_SR("sr_create",
-                             {'device': '/dev/sdb,/dev/sdc/,/dev/sdz'})
-        mock_validpath.side_effect = iter([True, True, False])
-        self.assertRaises(SR.SROSError, sr1.checkroot)
-
     def test_device_check_success(self):
         """
         Test the device check decorator with a device configured


### PR DESCRIPTION
If a device does not exist, then this is a separate error. If it does, then by definition its path is a valid one so the check is unnecessary and serves only to cause problems when new device has some unexpected (but valid) character in its name.

Likewise whether or not an NFS server path string is valid is the business of that NFS server, not the client code which is attempting to mount it.

Because checkroot() is removed (it has no remaining purpose), some subclasses of the SR class need to be modified as they relied on a side-effect of it being called.