### PR TITLE
Resolve hostname to determine which transport to use

### DIFF
--- a/drivers/NFSSR.py
+++ b/drivers/NFSSR.py
@@ -18,6 +18,9 @@
 # FileSR: local-file storage repository
 
 from __future__ import print_function
+
+import socket
+
 import SR
 import SRCommand
 import FileSR
@@ -263,7 +266,12 @@ class NFSSR(FileSR.SharedFileSR):
             # CA-365359: on_slave.is_open sends a dconf with {"server": None}
             return
 
-        use_ipv6 = util.get_ip_address_family(self.remoteserver) == 6
+        try:
+            addr_info = socket.getaddrinfo(self.remoteserver, 0)[0]
+        except Exception:
+            return
+
+        use_ipv6 = addr_info[0] == socket.AF_INET6
         if use_ipv6:
             self.transport = 'tcp6'
         if 'useUDP' in self.dconf and self.dconf['useUDP'] == 'true':

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -967,17 +967,6 @@ def remove_mpathcount_field(session, host_ref, sr_ref, SCSIid):
         pass
 
 
-def get_ip_address_family(address):
-    try:
-        socket.inet_aton(address)
-        return 4
-    except socket.error:
-        try:
-            socket.inet_pton(socket.AF_INET6, address)
-            return 6
-        except:
-            return -1
-
 
 def _testHost(hostname, port, errstring):
     SMlog("_testHost: Testing host/port: %s,%d" % (hostname, port))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,9 +92,3 @@ class TestCreate(unittest.TestCase):
             mock_log.assert_called_with(expectedMsg)
             mock_remove.assert_called_with("/var/run/random_temp.txt")
             self.assertEqual(opener_mock.return_value.close.call_count, 1)
-
-    def test_get_ip_address_family(self):
-        self.assertEqual(util.get_ip_address_family('127.0.0.1'), 4)
-        self.assertEqual(util.get_ip_address_family('::1'), 6)
-        self.assertEqual(util.get_ip_address_family('not an ip address'), -1)
-        self.assertEqual(util.get_ip_address_family('127.0.0.256'), -1)


### PR DESCRIPTION
- Use `getaddrinfo` on `dconf['server']`

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>