### PR TITLE
Harmonize indentation in multipath.conf

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -5,124 +5,123 @@
 # To check the currently running multipath configuration see the output of
 # `multipathd -k"show conf"`.
 defaults {
-	user_friendly_names	no
-	find_multipaths		yes
-	failback		10
-	no_path_retry		10
+    user_friendly_names     no
+    find_multipaths         yes
+    failback                10
+    no_path_retry           10
 }
 blacklist {
-	devnode	"^nvme.*"
-	devnode "scini*"
-	devnode "^rbd[0-9]*"
-	devnode "^nbd[0-9]*"
+    devnode "^nvme.*"
+    devnode "scini*"
+    devnode "^rbd[0-9]*"
+    devnode "^nbd[0-9]*"
 }
 # Leave this section in place even if empty
 blacklist_exceptions {
 }
 devices {
-	device {
-		vendor			"DataCore"
-		product			"SAN*"
-		path_checker		"tur"
-		path_grouping_policy	failover
-		failback		30
-	}
-	device {
-		vendor			"DELL"
-		product			"MD36xx(i|f)"
-		features		"2 pg_init_retries 50"
-		hardware_handler	"1 rdac"
-		path_selector		"round-robin 0"
-		path_grouping_policy	group_by_prio
-		failback		immediate
-		rr_min_io		100
-		path_checker		rdac
-		prio			rdac
-		no_path_retry		30
-	}
-	device {
-		vendor			"DellEMC"
-		product			"ME4"
-		path_grouping_policy	"group_by_prio"
-		path_checker		"tur"
-		hardware_handler	"1 alua"
-		prio			"alua"
-		failback		immediate
-		rr_weight		"uniform"
-		path_selector		"service-time 0"
-	}
-	device {
-		vendor			"DGC"
-		product			".*"
-		detect_prio		yes
-		retain_attached_hw_handler yes
-	}
-	device {
-		vendor			"EMC"
-		product			"Invista"
-		detect_prio		yes
-		retain_attached_hw_handler yes
-		path_grouping_policy	group_by_prio
-	}
-	device {
-		vendor			"EQLOGIC"
-		product			"100E-00"
-		path_grouping_policy	multibus
-		path_checker		readsector0
-		failback		immediate
-		path_selector		"round-robin 0"
-		rr_min_io		3
-		rr_weight		priorities
-	}
-	device {
-		vendor			"IBM"
-		product			"1723*"
-		hardware_handler	"1 rdac"
-		path_selector		"round-robin 0"
-		path_grouping_policy	group_by_prio
-		failback		immediate
-		path_checker		rdac
-		prio			rdac
-	}
-	device {
-		vendor			"LIO-ORG"
-		hardware_handler	"1 alua"
-		path_grouping_policy    "multibus"
-		path_selector	        "queue-length 0"
-		path_checker		tur
-		prio			alua
-		prio_args		exclusive_pref_bit
-		fast_io_fail_tmo	25
-	}
-	device {
-		vendor			"QNAP"
-		product			"iSCSI Storage"
-		path_grouping_policy    "multibus"
-		path_selector	        "round-robin 0"
-		path_checker	        readsector0
-		prio		        alua
-		uid_attribute		ID_SERIAL
-	}
     device {
-        vendor DellEMC
-        product PowerStore
-        path_selector "queue-length 0"
-        path_grouping_policy group_by_prio
-        path_checker tur
-        detect_prio yes
-        failback immediate
-        no_path_retry 3
-        rr_min_io_rq 1
-        fast_io_fail_tmo 15
-   }
-        device {
-                vendor                 "TrueNAS"
-                product                "iSCSI Disk"
-                hardware_handler       "1 alua"
-                retain_attached_hw_handler yes
-                path_grouping_policy   group_by_prio
-                prio                   alua
-                no_path_retry          60
-        }
-
+        vendor                      "DataCore"
+        product                     "SAN*"
+        path_checker                "tur"
+        path_grouping_policy        failover
+        failback                    30
+    }
+    device {
+        vendor                      "DELL"
+        product                     "MD36xx(i|f)"
+        features                    "2 pg_init_retries 50"
+        hardware_handler            "1 rdac"
+        path_selector               "round-robin 0"
+        path_grouping_policy        group_by_prio
+        failback                    immediate
+        rr_min_io                   100
+        path_checker                rdac
+        prio                        rdac
+        no_path_retry               30
+    }
+    device {
+        vendor                      "DellEMC"
+        product                     "ME4"
+        path_grouping_policy        "group_by_prio"
+        path_checker                "tur"
+        hardware_handler            "1 alua"
+        prio                        "alua"
+        failback                    immediate
+        rr_weight                   "uniform"
+        path_selector               "service-time 0"
+    }
+    device {
+        vendor                      "DGC"
+        product                     ".*"
+        detect_prio                 yes
+        retain_attached_hw_handler  yes
+    }
+    device {
+        vendor                      "EMC"
+        product                     "Invista"
+        detect_prio                 yes
+        retain_attached_hw_handler  yes
+        path_grouping_policy        group_by_prio
+    }
+    device {
+        vendor                      "EQLOGIC"
+        product                     "100E-00"
+        path_grouping_policy        multibus
+        path_checker                readsector0
+        failback                    immediate
+        path_selector               "round-robin 0"
+        rr_min_io                   3
+        rr_weight                   priorities
+    }
+    device {
+        vendor                      "IBM"
+        product                     "1723*"
+        hardware_handler            "1 rdac"
+        path_selector               "round-robin 0"
+        path_grouping_policy        group_by_prio
+        failback                    immediate
+        path_checker                rdac
+        prio                        rdac
+    }
+    device {
+        vendor                      "LIO-ORG"
+        hardware_handler            "1 alua"
+        path_grouping_policy        "multibus"
+        path_selector               "queue-length 0"
+        path_checker                tur
+        prio                        alua
+        prio_args                   exclusive_pref_bit
+        fast_io_fail_tmo            25
+    }
+    device {
+        vendor                      "QNAP"
+        product                     "iSCSI Storage"
+        path_grouping_policy        "multibus"
+        path_selector               "round-robin 0"
+        path_checker                readsector0
+        prio                        alua
+        uid_attribute               ID_SERIAL
+    }
+    device {
+        vendor                      DellEMC
+        product                     PowerStore
+        path_selector               "queue-length 0"
+        path_grouping_policy        group_by_prio
+        path_checker                tur
+        detect_prio                 yes
+        failback                    immediate
+        no_path_retry               3
+        rr_min_io_rq                1
+        fast_io_fail_tmo            15
+    }
+    device {
+        vendor                      "TrueNAS"
+        product                     "iSCSI Disk"
+        hardware_handler            "1 alua"
+        retain_attached_hw_handler  yes
+        path_grouping_policy        group_by_prio
+        prio                        alua
+        no_path_retry               60
+    }
 }


### PR DESCRIPTION
The file has evolved over years with a mix of spaces and tabs. Make it more consistent.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>

I opted for spaces and aligning the right values vertically. Other choices are possible.