### PR TITLE
Fix spelling of "XenServer" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,5 @@ Storage Manager for XenServer
 [![Coverage Status](https://coveralls.io/repos/xapi-project/sm/badge.png?branch=master)](https://coveralls.io/r/xapi-project/sm?branch=master)
 
 This repository contains the code which forms the Storage Management layer for
-XenSever. It consists of a series of "plug-ins" to xapi (the Xen management
+XenServer. It consists of a series of "plug-ins" to xapi (the Xen management
 layer) which are written primarily in python.


### PR DESCRIPTION
Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>

Not the most important PR for this project, but once you've seen the typo it can't be unseen, so I had to do it :)