### PR TITLE
Fix under-quoted backslashes by using raw strings

### DIFF
--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -56,7 +56,7 @@ NFSPORT = 2049
 
 def is_image_utf8_compatible(s):
     # pylint: disable=no-member
-    regex = re.compile("\.iso$|\.img$", re.I)
+    regex = re.compile(r"\.iso$|\.img$", re.I)
     if regex.search(s) is None:
         return False
 
@@ -120,7 +120,7 @@ class ISOSR(SR.SR):
 
     # pylint: disable=no-member
     uuid_file_regex = re.compile(
-        "([0-9a-f]{8}-(([0-9a-f]{4})-){3}[0-9a-f]{12})\.(iso|img)", re.I)
+        r"([0-9a-f]{8}-(([0-9a-f]{4})-){3}[0-9a-f]{12})\.(iso|img)", re.I)
 
     def _loadvdis(self):
         """Scan the directory and get uuids either from the VDI filename, \
@@ -176,7 +176,7 @@ class ISOSR(SR.SR):
         return super(ISOSR, self).content_type(sr_uuid)
 
     # pylint: disable=no-member
-    vdi_path_regex = re.compile("[a-z0-9.-]+\.(iso|img)", re.I)
+    vdi_path_regex = re.compile(r"[a-z0-9.-]+\.(iso|img)", re.I)
 
     def vdi(self, uuid):
         """Create a VDI class.  If the VDI does not exist, we determine

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -949,7 +949,7 @@ class Tapdisk(object):
 
     @staticmethod
     def _parse_minor(devpath):
-        regex = '%s/(blktap|tapdev)(\d+)$' % Blktap.DEV_BASEDIR
+        regex = r'%s/(blktap|tapdev)(\d+)$' % Blktap.DEV_BASEDIR
         pattern = re.compile(regex)
         groups = pattern.search(devpath)
         if not groups:

--- a/drivers/mpath_cli.py
+++ b/drivers/mpath_cli.py
@@ -57,8 +57,8 @@ def resize_map(m):
 def reconfigure():
     mpexec("reconfigure")
 
-regex = re.compile("[0-9]+:[0-9]+:[0-9]+:[0-9]+\s*([a-z]*)")
-regex2 = re.compile("multipathd>(\s*[^:]*:)?\s+(.*)")
+regex = re.compile(r"[0-9]+:[0-9]+:[0-9]+:[0-9]+\s*([a-z]*)")
+regex2 = re.compile(r"multipathd>(\s*[^:]*:)?\s+(.*)")
 regex3 = re.compile("switchgroup")
 
 

--- a/drivers/scsiutil.py
+++ b/drivers/scsiutil.py
@@ -94,7 +94,7 @@ def gen_uuid_from_string(src_string):
 
 def SCSIid_sanitise(str):
     text = str.strip()
-    return re.sub("\s+", "_", text)
+    return re.sub(r"\s+", "_", text)
 
 
 def getSCSIid(path):
@@ -138,7 +138,7 @@ def getserial(path):
     dev = os.path.join('/dev', getdev(path))
     try:
         cmd = ["sginfo", "-s", dev]
-        text = re.sub("\s+", "", util.pread2(cmd))
+        text = re.sub(r"\s+", "", util.pread2(cmd))
     except:
         raise xs_errors.XenError('EIO', \
               opterr='An error occured querying device serial number [%s]' \
@@ -162,7 +162,7 @@ def cacheSCSIidentifiers():
     SCSI = {}
     SYS_PATH = "/dev/disk/by-scsibus/*"
     for node in glob.glob(SYS_PATH):
-        if not re.match('.*-\d+:\d+:\d+:\d+$', node):
+        if not re.match(r'.*-\d+:\d+:\d+:\d+$', node):
             continue
         dev = os.path.realpath(node)
         HBTL = os.path.basename(node).split("-")[-1].split(":")
@@ -401,7 +401,7 @@ def _genReverseSCSidtoLUNidmap(SCSIid):
 
 
 def _dosgscan():
-    regex = re.compile("([^:]*):\s+scsi([0-9]+)\s+channel=([0-9]+)\s+id=([0-9]+)\s+lun=([0-9]+)")
+    regex = re.compile(r"([^:]*):\s+scsi([0-9]+)\s+channel=([0-9]+)\s+id=([0-9]+)\s+lun=([0-9]+)")
     scan = util.pread2(["/usr/bin/sg_scan"]).split('\n')
     sgs = []
     for line in scan:

--- a/drivers/wwid_conf.py
+++ b/drivers/wwid_conf.py
@@ -45,8 +45,8 @@ def edit_wwid(wwid, remove=False):
     """
 
     tmp_file = CONF_FILE + "~"
-    filt_regex = re.compile('^\s*%s\s*{' % BELIST_TAG)
-    wwid_regex = re.compile('^\s*wwid\s+\"%s\"' % wwid)
+    filt_regex = re.compile(r'^\s*%s\s*{' % BELIST_TAG)
+    wwid_regex = re.compile(r'^\s*wwid\s+\"%s\"' % wwid)
 
     conflock = lock.Lock(LOCK_TYPE_HOST, LOCK_NS)
     conflock.acquire()

--- a/tests/test_ISOSR.py
+++ b/tests/test_ISOSR.py
@@ -201,7 +201,7 @@ class TestISOSR_overSMB(unittest.TestCase):
         context.setup_error_codes()
         update = {'cifspassword': 'winter2019'}
         smbsr = self.create_smbisosr(atype='cifs', vers='1.0',
-                                     username='citrix\jsmith',
+                                     username=r'citrix\jsmith',
                                      dconf_update=update)
         _checkmount.side_effect = [False, True]
         smbsr.attach(None)


### PR DESCRIPTION
Running tests would show such warnings:

```
tests/test_ISOSR.py:201
  /data/src/sm/tests/test_ISOSR.py:201: DeprecationWarning: invalid escape sequence \j
    username='citrix\jsmith',

drivers/ISOSR.py:59
  /data/src/sm/drivers/ISOSR.py:59: DeprecationWarning: invalid escape sequence \.
    regex = re.compile("\.iso$|\.img$", re.I)
```