### PR TITLE
mk/sm.spec.in: remove uninstall operations now unrelated to this package

### DIFF
--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -100,12 +100,6 @@ exit 0
 %systemd_postun sm-mpath-root.service
 %systemd_postun xs-sm.service
 %systemd_postun storage-init.service
-if [ $1 -eq 0 ]; then
-    [ ! -d /etc/lvm/master ] || rm -Rf /etc/lvm/master || exit $?
-    cp -f /etc/lvm/lvm.conf.orig /etc/lvm/lvm.conf || exit $?
-elif [ $1 -eq 1 ]; then
-    true;
-fi
 
 %check
 tests/run_python_unittests.sh


### PR DESCRIPTION
Unless I have misunderstood the history of the sm and lvm2 packages, this uninstall code comes from previous times when the sm spec file itself contained more changes to the lvm2 configuration, changes that I think I have now seen in XS's lvm2 spec file (the creation of /etc/lvm/master/lvm.conf, for example).

I don't expect people to uninstall the sm package, but if I have not made a mistake, this is probably cleaner.