### PR TITLE
CA-375968: multi session iSCSI updates

### DIFF
--- a/drivers/LVHDoISCSISR.py
+++ b/drivers/LVHDoISCSISR.py
@@ -496,8 +496,8 @@ class LVHDoISCSISR(LVHDSR.LVHDSR):
                 try:
                     i.attach(sr_uuid)
                 except SR.SROSError as inst:
-                    # Some iscsi objects can fail login but not all. Storing exception
-                    if inst.errno == 141:
+                    # Some iscsi objects can fail login/discovery but not all. Storing exception
+                    if inst.errno in [141, 83]:
                         util.SMlog("Connection failed for target %s, continuing.." % i.target)
                         stored_exception = inst
                         continue


### PR DESCRIPTION
Make iSCSI multi session robust to discovery failures as well as login failures. Some of the sessions are permitted to fail so long as at least one successfully connects.