### PR TITLE
Get rid of vdi loadLocked parameter

### DIFF
--- a/drivers/EXTSR.py
+++ b/drivers/EXTSR.py
@@ -215,9 +215,7 @@ class EXTSR(FileSR.FileSR):
         scsiutil.add_serial_record(self.session, self.sr_ref, \
                   scsiutil.devlist_to_serialstring(self.dconf['device'].split(',')))
 
-    def vdi(self, uuid, loadLocked=False):
-        if not loadLocked:
-            return EXTFileVDI(self, uuid)
+    def vdi(self, uuid):
         return EXTFileVDI(self, uuid)
 
 

--- a/drivers/FileSR.py
+++ b/drivers/FileSR.py
@@ -233,7 +233,7 @@ class FileSR(SR.SR):
     def content_type(self, sr_uuid):
         return super(FileSR, self).content_type(sr_uuid)
 
-    def vdi(self, uuid, loadLocked=False):
+    def vdi(self, uuid):
         return FileVDI(self, uuid)
 
     def added_vdi(self, vdi):

--- a/drivers/FileSR.py
+++ b/drivers/FileSR.py
@@ -272,7 +272,7 @@ class FileSR(SR.SR):
         for uuid in self.vhds.keys():
             if self.vhds[uuid].error:
                 raise xs_errors.XenError('SRScan', opterr='uuid=%s' % uuid)
-            self.vdis[uuid] = self.vdi(uuid, True)
+            self.vdis[uuid] = self.vdi(uuid)
             # Get the key hash of any encrypted VDIs:
             vhd_path = os.path.join(self.path, self.vhds[uuid].path)
             key_hash = vhdutil.getKeyHash(vhd_path)
@@ -283,7 +283,7 @@ class FileSR(SR.SR):
         for fn in files:
             if fn.endswith(vhdutil.FILE_EXTN_RAW):
                 uuid = fn[:-(len(vhdutil.FILE_EXTN_RAW))]
-                self.vdis[uuid] = self.vdi(uuid, True)
+                self.vdis[uuid] = self.vdi(uuid)
             elif fn.endswith(CBTLOG_TAG):
                 cbt_uuid = fn.split(".")[0]
                 # If an associated disk exists, update CBT status

--- a/drivers/NFSSR.py
+++ b/drivers/NFSSR.py
@@ -243,9 +243,7 @@ class NFSSR(FileSR.SharedFileSR):
             if inst.code != errno.ENOENT:
                 raise xs_errors.XenError('NFSDelete')
 
-    def vdi(self, uuid, loadLocked=False):
-        if not loadLocked:
-            return NFSFileVDI(self, uuid)
+    def vdi(self, uuid):
         return NFSFileVDI(self, uuid)
 
     def scan_exports(self, target):

--- a/drivers/SMBSR.py
+++ b/drivers/SMBSR.py
@@ -287,9 +287,7 @@ class SMBSR(FileSR.SharedFileSR):
             if inst.code != errno.ENOENT:
                 raise xs_errors.XenError('SMBDelete')
 
-    def vdi(self, uuid, loadLocked=False):
-        if not loadLocked:
-            return SMBFileVDI(self, uuid)
+    def vdi(self, uuid):
         return SMBFileVDI(self, uuid)
 
 


### PR DESCRIPTION
The loadLocked parameter to .vdi() methods only hides duplicated code paths, so it appears we can get rid of it.