### PR TITLE
CA-376740: smb: Fix snapshot with newer kernels

### DIFF
--- a/drivers/SMBSR.py
+++ b/drivers/SMBSR.py
@@ -155,6 +155,15 @@ class SMBSR(FileSR.SharedFileSR):
                 'actimeo=0'
         ]
 
+	# Newer kernels defer closes by default but this interferes with use of
+	# hard links since with SMB (or maybe the underlying server
+	# filesystem), a hard link cannot be opened if the target is also
+	# open (which it will be with deferred close). Disable using the
+	# mount param, available since Linux 6.0.
+        kver_maj = int(os.uname()[2].split('.')[0])
+        if kver_maj >= 6:
+            options.append('closetimeo=0')
+
         if domain:
             options.append('domain=' + domain)
 


### PR DESCRIPTION
Newer kernels defer closes by default but this interferes with use of hard links since with SMB (or maybe the underlying server filesystem), a hard link cannot be opened if the target is also open, which it may be temporarily with deferred close. Disable using the mount param available since Linux 6.0.

This can be reproduced with the following Python snippet. When deferred close is enabled, the final open fails with EINVAL.

    fd = os.open('test.vhd', os.O_WRONLY|os.O_CREAT)
    os.write(fd, b'foo')
    os.close(fd)

    fd = os.open('test.vhd', os.O_RDONLY|os.O_DIRECT)
    os.close(fd)

    os.link('test.vhd', 'new.vhd')
    newfd = os.open('new.vhd', os.O_RDONLY|os.O_DIRECT)