### PR TITLE
CP-42222: Handle blk-mq noop and cfs schedulers

### DIFF
--- a/drivers/BaseISCSI.py
+++ b/drivers/BaseISCSI.py
@@ -419,7 +419,7 @@ class BaseISCSISR(SR.SR):
             devs = os.listdir("/dev/disk/by-scsid/%s" % self.dconf['SCSIid'])
             for dev in devs:
                 realdev = os.path.realpath("/dev/disk/by-scsid/%s/%s" % (self.dconf['SCSIid'], dev))
-                util.set_scheduler(realdev.split("/")[-1], "noop")
+                util.set_scheduler(realdev.split("/")[-1], ["none", "noop"])
 
     def detach(self, sr_uuid, delete=False):
         keys = []

--- a/drivers/LUNperVDI.py
+++ b/drivers/LUNperVDI.py
@@ -120,7 +120,7 @@ class RAWVDI(VDI.VDI):
                 devs = os.listdir("/dev/disk/by-scsid/%s" % self.sm_config['SCSIid'])
                 for dev in devs:
                     realdev = os.path.realpath("/dev/disk/by-scsid/%s/%s" % (self.sm_config['SCSIid'], dev))
-                    util.set_scheduler(realdev.split("/")[-1], "noop")
+                    util.set_scheduler(realdev.split("/")[-1], ["none", "noop"])
             if not util.wait_for_path(self.path, MAX_TIMEOUT):
                 util.SMlog("Unable to detect LUN attached to host [%s]" % self.sr.path)
                 raise xs_errors.XenError('VDIUnavailable')

--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -819,7 +819,7 @@ class Tapdisk(object):
                     try:
                         tapdisk = cls.__from_blktap(blktap)
                         node = '/sys/dev/block/%d:%d' % (tapdisk.major(), tapdisk.minor)
-                        util.set_scheduler_sysfs_node(node, 'noop')
+                        util.set_scheduler_sysfs_node(node, ['none', 'noop'])
                         return tapdisk
                     except:
                         TapCtl.close(pid, minor)


### PR DESCRIPTION
noop and cfq scheduler are dropped by 6.x linux kernel, to keep compatibility with 4.x linux kernel, following fallback is setup
* none -> noop
* bfq -> cfq