### PR TITLE
CA-379434: extend wait for multipath to 30 seconds

### DIFF
--- a/drivers/mpath_dmp.py
+++ b/drivers/mpath_dmp.py
@@ -170,7 +170,7 @@ def _refresh_DMP(sid, npaths):
             ['/usr/sbin/multipath', '-r', sid]),
                    maxretry=3,
                    period=4)
-        util.wait_for_path(path, 10)
+        util.wait_for_path(path, 30)
     if not os.path.exists(path):
         raise xs_errors.XenError('MultipathMapperPathMissing',
                                  'Device mapper path {} not found'.format(


### PR DESCRIPTION
Previous change in 65a6fa1 was incomplete and didn't fully address the issue as we also see failures in the previous wait_for_path.