### PR TITLE
CA-379315 Use XE_SR_ERRORCODES in the LVM journaller

### DIFF
--- a/drivers/XE_SR_ERRORCODES.xml
+++ b/drivers/XE_SR_ERRORCODES.xml
@@ -501,6 +501,13 @@
                 <value>116</value>
         </code>
 
+        <!-- An extra LVM error -->
+        <code>
+                <name>LVMRead</name>
+                <description>Logical Volume read error</description>
+                <value>117</value>
+        </code>
+
        <!-- Agent database query errors 150+ -->
         <code>
                 <name>APISession</name>

--- a/drivers/fjournaler.py
+++ b/drivers/fjournaler.py
@@ -19,9 +19,11 @@ import os
 import errno
 
 import util
-from journaler import JournalerException
 
 SEPARATOR = "_"
+
+class JournalerException(util.SMException):
+    pass
 
 
 class Journaler:

--- a/drivers/journaler.py
+++ b/drivers/journaler.py
@@ -18,14 +18,11 @@
 # LVM-based journaling
 
 import util
+import xs_errors
 from srmetadata import open_file, get_min_blk_size_wrapper, \
     file_read_wrapper, file_write_wrapper
 
 LVM_MAX_NAME_LEN = 127
-
-
-class JournalerException(util.SMException):
-    pass
 
 
 class Journaler:
@@ -49,8 +46,7 @@ class Journaler:
         valExisting = self.get(type, id)
         writeData = False
         if valExisting:
-            raise JournalerException("Journal already exists for '%s:%s': %s" \
-                    % (type, id, valExisting))
+            raise xs_errors.XenError('LVMCreate', opterr="Journal already exists for '%s:%s': %s" % (type, id, valExisting))
         lvName = self._getNameLV(type, id, val)
 
         mapperDevice = self._getLVMapperName(lvName)
@@ -93,15 +89,14 @@ class Journaler:
                 except Exception as e:
                     util.SMlog('WARNING: failed to clean up failed journal ' \
                             ' creation: %s (error ignored)' % e)
-                raise JournalerException("Failed to write to journal %s" \
-                    % lvName)
+                raise xs_errors.XenError('LVMWrite', opterr="Failed to write to journal %s" % lvName)
 
     def remove(self, type, id):
         """Remove the entry of type "type" for "id". Error if the entry doesn't
         exist."""
         val = self.get(type, id)
         if not val:
-            raise JournalerException("No journal for '%s:%s'" % (type, id))
+            raise xs_errors.XenError('LVMNoVolume', opterr="No journal for '%s:%s'" % (type, id))
         lvName = self._getNameLV(type, id, val)
 
         mapperDevice = self._getLVMapperName(lvName)
@@ -142,7 +137,7 @@ class Journaler:
         for lvName in lvList:
             parts = lvName.split(self.SEPARATOR, 2)
             if len(parts) != 3:
-                raise JournalerException("Bad LV name: %s" % lvName)
+                raise xs_errors.XenError('LVMNoVolume', opterr="Bad LV name: %s" % lvName)
             type, id, val = parts
             if readFile:
                 # For clone and leaf journals, additional
@@ -159,8 +154,7 @@ class Journaler:
                             length, val = data.split(" ", 1)
                             val = val[:int(length)]
                         except:
-                            raise JournalerException("Failed to read from journal %s" \
-                                  % lvName)
+                            raise xs_errors.XenError('LVMRead', opterr="Failed to read from journal %s" % lvName)
                     finally:
                         journal_file.close()
                         self.lvmCache.deactivateNoRefcount(lvName)

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1367,7 +1367,12 @@ fistpoint = FistPoint(["LVHDRT_finding_a_suitable_pair",
                         "cleanup_tracker_no_progress",
                         "FileSR_fail_hardlink",
                         "FileSR_fail_snap1",
-                        "FileSR_fail_snap2"])
+                        "FileSR_fail_snap2",
+                        "LVM_journaler_exists",
+                        "LVM_journaler_none",
+                        "LVM_journaler_badname",
+                        "LVM_journaler_readfail",
+                        "LVM_journaler_writefail"])
 
 
 def set_dirty(session, sr):

--- a/tests/test_fjournaler.py
+++ b/tests/test_fjournaler.py
@@ -4,7 +4,6 @@ import unittest
 import unittest.mock as mock
 
 import fjournaler
-import journaler
 
 TEST_DIR_PATH = '/var/lib/sometest'
 
@@ -131,9 +130,9 @@ class TestFjournaler(unittest.TestCase):
     def test_create_existing_error(self):
         self.subject.create('clone', '1', 'a')
 
-        with self.assertRaises(journaler.JournalerException):
+        with self.assertRaises(fjournaler.JournalerException):
             self.subject.create('clone', '1', 'a')
 
     def test_remove_non_existing_error(self):
-        with self.assertRaises(journaler.JournalerException):
+        with self.assertRaises(fjournaler.JournalerException):
             self.subject.remove('clone', '1')


### PR DESCRIPTION
Rather than allow JournalerExceptions to propagate up and eventually turn into "unhandled" error 1200s, turn all instances into the appropriate type of LVM error code and reture the JournalerException class, at least from the LVM journaller