### PR TITLE
CA-355289: if the SR is not plugged on GC startup wait a little while

### DIFF
--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -1532,12 +1532,20 @@ class SR:
             if force:
                 Util.log("SR %s not attached on this host, ignoring" % uuid)
             else:
-                raise util.SMException("SR %s not attached on this host" % uuid)
+                if not self.wait_for_plug():
+                    raise util.SMException("SR %s not attached on this host" % uuid)
 
         if force:
             Util.log("Not checking if we are Master (SR %s)" % uuid)
         elif not self.xapi.isMaster():
             raise util.SMException("This host is NOT master, will not run")
+
+    def wait_for_plug(self):
+        for _ in range(1, 10):
+            time.sleep(2)
+            if self.xapi.isPluggedHere():
+                return True
+        return False
 
     def gcEnabled(self, refresh=True):
         if refresh:

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1744,3 +1744,29 @@ class TestSR(unittest.TestCase):
         ## Assert
         mock_gc.assert_called_with(None, sr_uuid, False)
         mock_daemonize.assert_called_with()
+
+    def test_not_plugged(self):
+        """
+        GC called on an SR that is not plugged errors
+        """
+        # Arrange
+        self.xapi_mock.isPluggedHere.return_value = False
+
+        # Act
+        with self.assertRaises(util.SMException):
+            create_cleanup_sr(self.xapi_mock)
+
+    def test_not_plugged_retry(self):
+        """
+        GC called on an SR that is not plugged retrys
+        """
+        # Arrange
+        self.xapi_mock.isPluggedHere.side_effect = [
+            False, False, False, True]
+
+        # Act
+        sr = create_cleanup_sr(self.xapi_mock)
+
+        # Assert
+        self.assertIsNotNone(sr)
+


### PR DESCRIPTION
The GC can be started by an on attach SR scan and sometimes complains that the SR is, according to Xapi, not plugged on the host. When encountering this error pause and retry a few times before giving up.

```
 > <hostname> SMGC: [<pid>] *~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
 > <hostname> SMGC: [<pid>]          ***********************
 > <hostname> SMGC: [<pid>]          *  E X C E P T I O N  *
 > <hostname> SMGC: [<pid>]          ***********************<
 > <hostname> SMGC: [<pid>] gc: EXCEPTION <class 'util.SMException'>, SR <uuid> not attached on this host
 > <hostname> SMGC: [<pid>]   File "/opt/xensource/sm/cleanup.py", line 3174, in gc
 > <hostname> SMGC: [<pid>]     _gc(None, srUuid, dryRun)
 > <hostname> SMGC: [<pid>]   File "/opt/xensource/sm/cleanup.py", line 3049, in _gc
 > <hostname> SMGC: [<pid>]     sr = SR.getInstance(srUuid, session)
 > <hostname> SMGC: [<pid>]   File "/opt/xensource/sm/cleanup.py", line 1518, in getInstance
 > <hostname> SMGC: [<pid>]     return LVHDSR(uuid, xapi, createLock, force)
 > <hostname> SMGC: [<pid>]   File "/opt/xensource/sm/cleanup.py", line 2565, in __init__
 > <hostname> SMGC: [<pid>]     SR.__init__(self, uuid, xapi, createLock, force)
 > <hostname> SMGC: [<pid>]   File "/opt/xensource/sm/cleanup.py", line 1544, in __init__
 > <hostname> SMGC: [<pid>]     raise util.SMException("SR %s not attached on this host" % uuid)
 > <hostname> SMGC: [<pid>]
 > <hostname> SMGC: [<pid>] *~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
 > <hostname> SMGC: [<pid>] * * * * * SR <uuid>: ERROR
```