### PR TITLE
Update multipath.conf with support for HP/HPE MSA storage appliances

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -132,4 +132,14 @@ devices {
         prio                        alua
         no_path_retry               60
     }
+    device {
+        vendor                      "HP|HPE"
+        product                     "MSA [12]0[456]0*"
+        path_selector               "round-robin 0"
+        hardware_handler            "1 alua"
+        path_grouping_policy        group_by_prio
+        prio                        alua
+        failback                    immediate
+        no_path_retry               18
+    }
 }

--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -133,8 +133,8 @@ devices {
         no_path_retry               60
     }
     device {
-        vendor                      "HP|HPE"
-        product                     "MSA [12]0[456]0*"
+        vendor                      "(HP|HPE)"
+        product                     "MSA [12]0[456]0 .*"
         path_selector               "round-robin 0"
         hardware_handler            "1 alua"
         path_grouping_policy        group_by_prio


### PR DESCRIPTION
Added support for HP/HPE MSA storage appliances such as the HP MSA2050 and HPE MSA2060.

The added configuration settings were sourced from the following location: https://community.hpe.com/t5/msa-storage/msa-2060-sas-red-hat-8-multipathing/td-p/7163998 As well as my own experience, here:
https://xcp-ng.org/forum/topic/6553/can-t-create-sr-on-fibre-channel-storage-msa2062-sr_backend_failure_53/