### PR TITLE
CA-282738: fix bad exception thrown in mountOverSMB

### DIFF
--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -417,7 +417,7 @@ class ISOSR(SR.SR):
             util.SMlog("Exception: %s" % str(exc))
             if self._checkmount():
                 util.pread(["umount", self.mountpoint])
-            raise util.CommandException
+            raise xs_errors.XenError('SMBMount') from exc
 
     def updateSMBVersInPBDConfig(self):
         """Store smb version in PBD config"""

--- a/tests/test_testlib.py
+++ b/tests/test_testlib.py
@@ -363,6 +363,18 @@ class TestTestContext(unittest.TestCase):
             context.fake_rmdir('/existing_dir')
         self.assertEqual(errno.ENOTEMPTY, cm.exception.errno)
 
+    def test_get_error_code(self):
+        context = testlib.TestContext()
+        self.assertEqual(context.get_error_code("SMBMount"), 111)
+
+    def test_get_error_code_not_found(self):
+        """
+        When error code can't be found then None is returned.
+        This test is to keep 100% coverage on tests.
+        """
+        context = testlib.TestContext()
+        self.assertEqual(context.get_error_code("PANCAKES"), None)
+
 
 class TestFilesystemFor(unittest.TestCase):
     def test_returns_single_item_for_root(self):

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -8,6 +8,8 @@ import random
 import textwrap
 import errno
 
+from xml.dom.minidom import parseString
+
 PATHSEP = '/'
 
 
@@ -322,6 +324,14 @@ class TestContext(object):
     def add_adapter(self, adapter):
         self.scsi_adapters.append(adapter)
         return adapter
+
+    def get_error_code(self, error_name):
+        xml = parseString(self.error_codes)
+        for code in xml.getElementsByTagName('code'):
+            name = code.getElementsByTagName('name')[0].firstChild.nodeValue
+            if name == error_name:
+                return int(code.getElementsByTagName('value')[0].firstChild.nodeValue)
+        return None
 
     @staticmethod
     def is_binary(mode):


### PR DESCRIPTION
This change fixes `raise util.CommandException` not passing in enough arguments and throwing an unexpected `TypeError` inside `mountOverSMB`. The exception has been replaced with `XenError`. [b7eea5d2452]

A unit test was added to cover this code path.

A new method `get_error_code` was added to `testlib` to retrieve error codes from error names by parsing `XE_SR_ERRORCODES.xml` e.g. `get_error_code("SMBMount")` => `111`. This is to avoid hardcoding the error codes as magic numbers in the test. [db0c877b595]

New `testlib` unit tests added for new `get_error_code` method because build will fail without 100% coverage on test files. [ca4e932ef31]

The code change and an early version of the unit test were ran through Storage: BST (run 187746).
