### PR TITLE
CA-372064: storage-init don't try to make Local storage if it already exists.

### DIFF
--- a/scripts/storage-init
+++ b/scripts/storage-init
@@ -290,8 +290,14 @@ configure_multipathing() {
 }
 
 if [ ! "$UPGRADE" = "true" ]; then
-  create_local_sr
-  set_default_sr
+  if [[ -z "$(xe sr-list name-label="Local storage" | awk -F: '/uuid/ {print $2}')" ]]
+  then
+    create_local_sr
+    set_default_sr
+  else
+    echo "Existing local SR detected, skip create_local_sr"
+  fi
+
   create_udev_srs
   configure_multipathing
   # Ensure changes are synced to disk


### PR DESCRIPTION
If a user creates their own Local Storage manually before XenServer first
boots then sm/scripts/storage-init will delete it and try to create another
one leaving the volume groups in a messy unusable state. This bug can also be
replicated by simply calling storage-init again manually after XenServer has
already been installed.

This change modifies storage-init to not touch Local Storage if it already
exists.

This was tested by doing a new XenServer install and checking that the Local
Storage is created as normal. Then storage-init was called a second time
manually and confirmed the volume groups were not modified.

