### PR TITLE
CA-381221: Increase NFS timeouts to the expected value

### DIFF
--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -281,7 +281,7 @@ def get_supported_nfs_versions(server):
 
 
 def get_nfs_timeout(other_config):
-    nfs_timeout = 100
+    nfs_timeout = 200
 
     if 'nfs-timeout' in other_config:
         val = int(other_config['nfs-timeout'])
@@ -294,7 +294,7 @@ def get_nfs_timeout(other_config):
 
 
 def get_nfs_retrans(other_config):
-    nfs_retrans = 3
+    nfs_retrans = 4
 
     if 'nfs-retrans' in other_config:
         val = int(other_config['nfs-retrans'])

--- a/tests/test_ISOSR.py
+++ b/tests/test_ISOSR.py
@@ -88,8 +88,8 @@ class TestISOSR_overNFS(unittest.TestCase):
                                            'aServer',
                                            '/aLocation',
                                            'tcp',
-                                           retrans=3,
-                                           timeout=100,
+                                           retrans=4,
+                                           timeout=200,
                                            useroptions='',
                                            nfsversion='aNfsversionChanged')
 

--- a/tests/test_NFSSR.py
+++ b/tests/test_NFSSR.py
@@ -128,9 +128,9 @@ class TestNFSSR(unittest.TestCase):
                                            '/aServerpath/UUID',
                                            'tcp',
                                            useroptions='options',
-                                           timeout=100,
+                                           timeout=200,
                                            nfsversion='aNfsversionChanged',
-                                           retrans=3)
+                                           retrans=4)
 
     @mock.patch('NFSSR.Lock', autospec=True)
     def test_load_ipv6(self, mock_lock):


### PR DESCRIPTION
Newer kernels have more reliable NFS timeouts but they also do not behave quite like the manpage describes regarding major timeouts with soft TCP NFS mounts.

From experimentation and reading the code, a major timeout occurs after min(600, (timeo/10) * (retrans + 1)) seconds.

With the current defaults, that means 40 seconds. However, the intention with CA-302514 was to set it to 100 seconds so increase timeo and retrans accordingly.