### PR TITLE
CA-339581: Report NFS version incompatibilities for ISO SRs

### DIFF
--- a/tests/test_ISOSR.py
+++ b/tests/test_ISOSR.py
@@ -72,15 +72,17 @@ class TestISOSR_overNFS(unittest.TestCase):
     @mock.patch('nfs.validate_nfsversion', autospec=True)
     @mock.patch('util.makedirs', autospec=True)
     @mock.patch('util._testHost', autospec=True)
+    @mock.patch('nfs.check_server_tcp', autospec=True)
     # Can't use autospec due to http://bugs.python.org/issue17826
     @mock.patch('ISOSR.ISOSR._checkmount')
-    def test_attach_nfs(self, _checkmount, testHost, makedirs,
+    def test_attach_nfs(self, _checkmount, check_server_tcp, testHost, makedirs,
                         validate_nfsversion, convertDNS, soft_mount, gen_uuid):
         validate_nfsversion.return_value = 'aNfsversionChanged'
         isosr = self.create_isosr(location='aServer:/aLocation', atype='nfs_iso',
                                   sr_uuid='asr_uuid')
         _checkmount.side_effect = [False, True]
         gen_uuid.return_value = 'aUuid'
+        check_server_tcp.return_value = ['aNfsversionChanged']
 
         isosr.attach(None)
 
@@ -114,6 +116,34 @@ class TestISOSR_overNFS(unittest.TestCase):
             isosr.attach(None)
 
         self.assertEqual(140, ose.exception.errno)
+
+    @testlib.with_context
+    @mock.patch('util.gen_uuid', autospec=True)
+    @mock.patch('nfs.soft_mount', autospec=True)
+    @mock.patch('util._convertDNS', autospec=True)
+    @mock.patch('nfs.validate_nfsversion', autospec=True)
+    @mock.patch('util.makedirs', autospec=True)
+    @mock.patch('util._testHost', autospec=True)
+    @mock.patch('nfs.check_server_tcp', autospec=True)
+    # Can't use autospec due to http://bugs.python.org/issue17826
+    @mock.patch('ISOSR.ISOSR._checkmount')
+    def test_attach_nfs_wrong_version(
+            self, context, _checkmount, check_server_tcp, testHost, makedirs,
+            validate_nfsversion, convertDNS, soft_mount, gen_uuid):
+        context.setup_error_codes()
+
+        isosr = self.create_isosr(location='aServer:/aLocation', atype='nfs_iso',
+                                  sr_uuid='asr_uuid')
+
+        _checkmount.return_value = False
+        validate_nfsversion.return_value = '4'
+        check_server_tcp.return_value = False
+
+        with self.assertRaises(SR.SROSError) as cm:
+            isosr.attach(None)
+
+        self.assertRegex(str(cm.exception),
+                         r"^Required NFS server version unsupported\b")
 
 
 class TestISOSR_overSMB(unittest.TestCase):


### PR DESCRIPTION
Have ISOSR check for NFS version compatibility as well the presence of a running server, when preparing to for an NFS ISO mount. Also, have this checking done prior to the creation of a mountpoint.

Testing:
--------
I created an NFS server configured for version 3, and then tried to create an SR for it by using xe from dom0. Prior to this change, trying to create an ISO SR specifying an incompatible NFS version with
```
xe sr-create type=iso name-label=scratch device-config:nfsversion=4 device-config:location=my_nfs_server:/scratch
```
gives
```
Error code: SR_BACKEND_FAILURE_222
Error parameters: , Could not mount the directory specified in Device Configuration [opterr=mount failed on server `my_nfs_server` with return code 110],
```

With this change, doing the same thing gives:
```
Error code: SR_BACKEND_FAILURE_72
Error parameters: , Required NFS server version unsupported [opterr=Unsupported NFS version: 4],
```

Also with this change, if I repeat this by specify nfsversion=3, the SR is successfully created.