### PR TITLE
CA-339581: Report NFS version incompatibilities for ISO SRs

### DIFF
--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -52,6 +52,7 @@ TYPE = "iso"
 SMB_VERSION_1 = '1.0'
 SMB_VERSION_3 = '3.0'
 NFSPORT = 2049
+NFSTRANSPORT = "tcp"
 
 
 def is_image_utf8_compatible(s):
@@ -261,20 +262,24 @@ class ISOSR(SR.SR):
         if self._checkmount():
             return
 
+        location = util.to_plain_string(self.dconf['location'])
+        # TODO: Have XC standardise iso type string
+        if 'type' in self.dconf:
+            protocol = self.dconf['type']
+        elif ":/" in location:
+            protocol = 'nfs_iso'
+        else:
+            protocol = 'cifs'
+
+        if protocol == 'nfs_iso':
+            self._check_nfs_server(location)
+
         # Create the mountpoint if it's not already there
         if not util.isdir(self.mountpoint):
             util.makedirs(self.mountpoint)
 
         mountcmd = []
-        location = util.to_plain_string(self.dconf['location'])
-        # TODO: Have XC standardise iso type string
-        protocol = 'nfs_iso'
         options = ''
-
-        if 'type' in self.dconf:
-            protocol = self.dconf['type']
-        elif ":/" not in location:
-            protocol = 'cifs'
 
         if 'options' in self.dconf:
             options = self.dconf['options'].split(' ')
@@ -386,6 +391,24 @@ class ISOSR(SR.SR):
         if not self._checkmount():
             self.detach(sr_uuid)
             raise xs_errors.XenError('ISOSharenameFailure')
+
+    def _check_nfs_server(self, location):
+        """
+        Given that we want to mount a given NFS share, checks that there is an
+        NFS server running in the remote server, and that it supports the
+        desired NFS version. Raises an appropriate exception if this is not
+        the case.
+        """
+        serv_path = location.split(':')
+
+        try:
+            util._testHost(serv_path[0], NFSPORT, 'NFSTarget')
+            if not nfs.check_server_tcp(serv_path[0], NFSTRANSPORT, self.nfsversion):
+                raise xs_errors.XenError('NFSVersion',
+                                         opterr="Unsupported NFS version: %s" % self.nfsversion)
+        except nfs.NfsException as e:
+            raise xs_errors.XenError('NFSTarget', opterr=str(e.errstr))
+
 
     def after_master_attach(self, uuid):
         """Perform actions required after attaching on the pool master

--- a/tests/test_ISOSR.py
+++ b/tests/test_ISOSR.py
@@ -72,15 +72,17 @@ class TestISOSR_overNFS(unittest.TestCase):
     @mock.patch('nfs.validate_nfsversion', autospec=True)
     @mock.patch('util.makedirs', autospec=True)
     @mock.patch('util._testHost', autospec=True)
+    @mock.patch('nfs.check_server_tcp', autospec=True)
     # Can't use autospec due to http://bugs.python.org/issue17826
     @mock.patch('ISOSR.ISOSR._checkmount')
-    def test_attach_nfs(self, _checkmount, testHost, makedirs,
+    def test_attach_nfs(self, _checkmount, check_server_tcp, testHost, makedirs,
                         validate_nfsversion, convertDNS, soft_mount, gen_uuid):
         validate_nfsversion.return_value = 'aNfsversionChanged'
         isosr = self.create_isosr(location='aServer:/aLocation', atype='nfs_iso',
                                   sr_uuid='asr_uuid')
         _checkmount.side_effect = [False, True]
         gen_uuid.return_value = 'aUuid'
+        check_server_tcp.return_value = ['aNfsversionChanged']
 
         isosr.attach(None)
 
@@ -114,6 +116,34 @@ class TestISOSR_overNFS(unittest.TestCase):
             isosr.attach(None)
 
         self.assertEqual(140, ose.exception.errno)
+
+    @testlib.with_context
+    @mock.patch('util.gen_uuid', autospec=True)
+    @mock.patch('nfs.soft_mount', autospec=True)
+    @mock.patch('util._convertDNS', autospec=True)
+    @mock.patch('nfs.validate_nfsversion', autospec=True)
+    @mock.patch('util.makedirs', autospec=True)
+    @mock.patch('util._testHost', autospec=True)
+    @mock.patch('nfs.check_server_tcp', autospec=True)
+    # Can't use autospec due to http://bugs.python.org/issue17826
+    @mock.patch('ISOSR.ISOSR._checkmount')
+    def test_attach_nfs_wrong_version(
+            self, context, _checkmount, check_server_tcp, testHost, makedirs,
+            validate_nfsversion, convertDNS, soft_mount, gen_uuid):
+        context.setup_error_codes()
+
+        isosr = self.create_isosr(location='aServer:/aLocation', atype='nfs_iso',
+                                  sr_uuid='asr_uuid')
+
+        _checkmount.return_value = False
+        validate_nfsversion.return_value = '4'
+        check_server_tcp.return_value = False
+
+        with self.assertRaises(SR.SROSError) as cm:
+            isosr.attach(None)
+
+        self.assertRegex(str(cm.exception),
+                         r"^Required NFS server version unsupported\b")
 
 
 class TestISOSR_overSMB(unittest.TestCase):


### PR DESCRIPTION
Have ISOSR check for NFS version compatibility as well the presence of a running server, when preparing to for an NFS ISO mount. Also, have this checking done prior to the creation of a mountpoint.