### PR TITLE
CA-339581 Unbreak NFS ipv6 support in ISOSR

### DIFF
--- a/tests/test_ISOSR.py
+++ b/tests/test_ISOSR.py
@@ -86,10 +86,51 @@ class TestISOSR_overNFS(unittest.TestCase):
 
         isosr.attach(None)
 
+        testHost.assert_called_once_with('aServer', 2049, 'NFSTarget')
+
+        check_server_tcp.assert_called_once_with('aServer',
+                                                 'tcp',
+                                                 'aNfsversionChanged')
+
         soft_mount.assert_called_once_with('/var/run/sr-mount/asr_uuid',
                                            'aServer',
                                            '/aLocation',
                                            'tcp',
+                                           retrans=4,
+                                           timeout=200,
+                                           useroptions='',
+                                           nfsversion='aNfsversionChanged')
+
+    @mock.patch('util.gen_uuid', autospec=True)
+    @mock.patch('nfs.soft_mount', autospec=True)
+    @mock.patch('util._convertDNS', autospec=True)
+    @mock.patch('nfs.validate_nfsversion', autospec=True)
+    @mock.patch('util.makedirs', autospec=True)
+    @mock.patch('util._testHost', autospec=True)
+    @mock.patch('nfs.check_server_tcp', autospec=True)
+    # Can't use autospec due to http://bugs.python.org/issue17826
+    @mock.patch('ISOSR.ISOSR._checkmount')
+    def test_attach_nfs_ipv6(self, _checkmount, check_server_tcp, testHost, makedirs,
+                        validate_nfsversion, convertDNS, soft_mount, gen_uuid):
+        validate_nfsversion.return_value = 'aNfsversionChanged'
+        isosr = self.create_isosr(location='[aServer]:/aLocation', atype='nfs_iso',
+                                  sr_uuid='asr_uuid')
+        _checkmount.side_effect = [False, True]
+        gen_uuid.return_value = 'aUuid'
+        check_server_tcp.return_value = ['aNfsversionChanged']
+
+        isosr.attach(None)
+
+        testHost.assert_called_once_with('aServer', 2049, 'NFSTarget')
+
+        check_server_tcp.assert_called_once_with('aServer',
+                                                 'tcp6',
+                                                 'aNfsversionChanged')
+
+        soft_mount.assert_called_once_with('/var/run/sr-mount/asr_uuid',
+                                           'aServer',
+                                           '/aLocation',
+                                           'tcp6',
                                            retrans=4,
                                            timeout=200,
                                            useroptions='',


### PR DESCRIPTION
Pre-mount checking of an NFS server was failing in the face of a ipv6 share location, as it didn't how to understand the form of the location string. The logic of parsing NFS location strings has now been unified, to avoid this problem.