### PR TITLE
CA-379287 and CP-383791: non-ascii VDI names 

### DIFF
--- a/drivers/SRCommand.py
+++ b/drivers/SRCommand.py
@@ -83,7 +83,7 @@ class SRCommand:
         #                                  priority=util.LOG_DEBUG )
 
         try:
-            params, methodname = xmlrpc.client.loads(sys.argv[1])
+            params, methodname = xmlrpc.client.loads(os.fsencode(sys.argv[1]))
             self.cmd = methodname
             params = params[0]  # expect a single struct
             self.params = params

--- a/drivers/journaler.py
+++ b/drivers/journaler.py
@@ -63,7 +63,7 @@ class Journaler:
             try:
                 e = None
                 try:
-                    data = "%d %s" % (len(val), val)
+                    data = ("%d %s" % (len(val), val)).encode()
                     file_write_wrapper(journal_file, 0, data)
                     if util.fistpoint.is_active("LVM_journaler_writefail"):
                         raise ValueError("LVM_journaler_writefail FistPoint active")
@@ -150,7 +150,7 @@ class Journaler:
                     try:
                         try:
                             data = file_read_wrapper(journal_file, 0)
-                            length, val = data.split(" ", 1)
+                            length, val = data.decode().split(" ", 1)
                             val = val[:int(length)]
                             if util.fistpoint.is_active("LVM_journaler_readfail"):
                                 raise ValueError("LVM_journaler_readfail FistPoint active")

--- a/drivers/journaler.py
+++ b/drivers/journaler.py
@@ -19,8 +19,7 @@
 
 import util
 import xs_errors
-from srmetadata import open_file, get_min_blk_size_wrapper, \
-    file_read_wrapper, file_write_wrapper
+from srmetadata import open_file, file_read_wrapper, file_write_wrapper
 
 LVM_MAX_NAME_LEN = 127
 
@@ -64,9 +63,8 @@ class Journaler:
             try:
                 e = None
                 try:
-                    min_block_size = get_min_blk_size_wrapper(journal_file)
                     data = "%d %s" % (len(val), val)
-                    file_write_wrapper(journal_file, 0, min_block_size, data, len(data))
+                    file_write_wrapper(journal_file, 0, data)
                     if util.fistpoint.is_active("LVM_journaler_writefail"):
                         raise ValueError("LVM_journaler_writefail FistPoint active")
                 except Exception as e:
@@ -151,8 +149,7 @@ class Journaler:
                     journal_file = open_file(fullPath)
                     try:
                         try:
-                            min_block_size = get_min_blk_size_wrapper(journal_file)
-                            data = file_read_wrapper(journal_file, 0, min_block_size, min_block_size)
+                            data = file_read_wrapper(journal_file, 0)
                             length, val = data.split(" ", 1)
                             val = val[:int(length)]
                             if util.fistpoint.is_active("LVM_journaler_readfail"):

--- a/drivers/srmetadata.py
+++ b/drivers/srmetadata.py
@@ -89,10 +89,12 @@ def open_file(path, write=False):
     return file_p
 
 
-# Writes data to a file at a given offset. Padding (consisting of spaces) may
-# be written out after the given data to ensure that complete blocks are
-# written.
 def file_write_wrapper(fd, offset, data):
+    """
+    Writes data to a file at a given offset. Padding (consisting of spaces)
+    may be written out after the given data to ensure that complete blocks are
+    written.
+    """
     try:
         blocksize = METADATA_BLK_SIZE
         length = len(data)
@@ -108,9 +110,11 @@ def file_write_wrapper(fd, offset, data):
             ([fd, offset, blocksize, data], e.errno))
 
 
-# Reads data from a file at a given offset. If not specified, the amount of
-# data to read defaults to one block.
 def file_read_wrapper(fd, offset, bytesToRead=METADATA_BLK_SIZE):
+    """
+    Reads data from a file at a given offset. If not specified, the amount of
+    data to read defaults to one block.
+    """
     try:
         fd.seek(offset, SEEK_SET)
         return fd.read(bytesToRead)

--- a/drivers/srmetadata.py
+++ b/drivers/srmetadata.py
@@ -35,6 +35,15 @@ import xml.sax.saxutils
 # having been deleted, in which case the sectors used to contain this info can
 # potentially be reused when a new VDI is subsequently added.
 
+# String data in this module takes the form of normal Python unicode `str`
+# instances, or UTF-8 encoded `bytes`, depending on circumstance. In `dict`
+# instances such as are used to represent SR and VDI info, `str` is used (as
+# these may be returned to, or have been supplied by, this module's callers).
+# Data going into or taken from a metadata file is `bytes`. XML and XML
+# fragments come under this category, so are `bytes`. XML tag names are `str`
+# instances, as these are also used as `dict` keys.
+
+
 SECTOR_SIZE = 512
 XML_HEADER = b"<?xml version=\"1.0\" ?>"
 MAX_METADATA_LENGTH_SIZE = 10
@@ -122,15 +131,6 @@ def file_read_wrapper(fd, offset, bytesToRead=METADATA_BLK_SIZE):
         raise OSError(
             "Failed to read file with params %s. Error: %s" %
             ([fd, offset, bytesToRead], e.errno))
-
-
-# String data in this module takes the form of normal Python unicode `str`
-# instances, or UTF-8 encoded `bytes`, depending on circumstance. In `dict`
-# instances such as are used to represent SR and VDI info, `str` is used (as
-# these may be returned to, or have been supplied by, this module's callers).
-# Data going into or taken from a metadata file is `bytes`. XML and XML
-# fragments come under this category, so are `bytes`. XML tag names are `str`
-# instances, as these are also used as `dict` keys.
 
 
 def to_utf8(s):

--- a/drivers/srmetadata.py
+++ b/drivers/srmetadata.py
@@ -24,12 +24,20 @@ import xs_errors
 import lvutil
 import xml.sax.saxutils
 
+# A metadata file is considered to be made up of 512 byte sectors.
+# Most of the information in it is in the form of fragments of XML.
+# The first four contain SR information - well, the first actually
+# contains a header, and the next three contain bits of XML representing SR
+# info, but the four are treated as a unit. Information in the header includes
+# the length of the part of the file that's in use.
+# Subsequent sectors, if they are in use, contain VDI information - in the LVM
+# case they take two sectors each. VDI information might mark the VDI as
+# having been deleted, in which case the sectors used to contain this info can
+# potentially be reused when a new VDI is subsequently added.
+
 SECTOR_SIZE = 512
 XML_HEADER = "<?xml version=\"1.0\" ?>"
-SECTOR2_FMT = "%s%s%s"
 MAX_METADATA_LENGTH_SIZE = 10
-LEN_FMT = "%" + "-%ds" % MAX_METADATA_LENGTH_SIZE
-SECTOR_STRUCT = "%-512s"
 OFFSET_TAG = 'offset'
 
 # define xml tags for metadata
@@ -37,7 +45,6 @@ ALLOCATION_TAG = 'allocation'
 NAME_LABEL_TAG = 'name_label'
 NAME_DESCRIPTION_TAG = 'name_description'
 VDI_TAG = 'vdi'
-VDI_CLOSING_TAG = '</%s>' % VDI_TAG
 VDI_DELETED_TAG = 'deleted'
 UUID_TAG = 'uuid'
 IS_A_SNAPSHOT_TAG = 'is_a_snapshot'
@@ -50,13 +57,6 @@ SNAPSHOT_TIME_TAG = 'snapshot_time'
 METADATA_OF_POOL_TAG = 'metadata_of_pool'
 SVID_TAG = 'svid'
 LUN_LABEL_TAG = 'll'
-VDI_SECTOR_1 = "<%s><%s>%s</%s><%s>%s</%s>" % (VDI_TAG,
-                                               NAME_LABEL_TAG,
-                                               '%s',
-                                               NAME_LABEL_TAG,
-                                               NAME_DESCRIPTION_TAG,
-                                               '%s',
-                                               NAME_DESCRIPTION_TAG)
 MAX_VDI_NAME_LABEL_DESC_LENGTH = SECTOR_SIZE - 2 * len(NAME_LABEL_TAG) - \
     2 * len(NAME_DESCRIPTION_TAG) - len(VDI_TAG) - 12
 
@@ -71,10 +71,6 @@ METADATA_BLK_SIZE = 512
 
 
 # ----------------- # General helper functions - begin # -----------------
-def get_min_blk_size_wrapper(fd):
-    return METADATA_BLK_SIZE
-
-
 def open_file(path, write=False):
     if write:
         try:
@@ -93,8 +89,13 @@ def open_file(path, write=False):
     return file_p
 
 
-def file_write_wrapper(fd, offset, blocksize, data, length):
+# Writes data to a file at a given offset. Padding (consisting of spaces) may
+# be written out after the given data to ensure that complete blocks are
+# written.
+def file_write_wrapper(fd, offset, data):
     try:
+        blocksize = METADATA_BLK_SIZE
+        length = len(data)
         newlength = length
         if length % blocksize:
             newlength = length + (blocksize - length % blocksize)
@@ -104,24 +105,34 @@ def file_write_wrapper(fd, offset, blocksize, data, length):
     except OSError as e:
         raise OSError(
             "Failed to write file with params %s. Error: %s" %
-            ([fd, offset, blocksize, data, length], e.errno))
+            ([fd, offset, blocksize, data], e.errno))
     return result
 
 
-def file_read_wrapper(fd, offset, bytesToRead, min_block_size):
+# Reads data from a file at a given offset. If not specified, the amount of
+# data to read defaults to one block.
+def file_read_wrapper(fd, offset, bytesToRead=METADATA_BLK_SIZE):
     try:
         fd.seek(offset, SEEK_SET)
         result = fd.read(bytesToRead)
     except OSError as e:
         raise OSError(
             "Failed to read file with params %s. Error: %s" %
-            ([fd, offset, min_block_size, bytesToRead], e.errno))
+            ([fd, offset, bytesToRead], e.errno))
     return result.decode()
 
 
 # get a range which is block aligned, contains 'offset' and allows
 # length bytes to be written
-def getBlockAlignedRange(block_size, offset, length):
+def getBlockAlignedRange(offset, length):
+    # It looks like offsets and lengths are in reality always sector aligned,
+    # and since a block and a sector are the same size we could probably do
+    # without this code.
+    # There methods elsewhere in this module (updateSR, getMetadataForWrite)
+    # that appear try to cope with the possibility of the block-aligned range
+    # for SR info also containing VDI info, or vice versa. On the face of it,
+    # that's impossible, and so there's scope for simplification there too.
+    block_size = METADATA_BLK_SIZE
     lower = 0
     if offset % block_size == 0:
         lower = offset
@@ -136,17 +147,15 @@ def getBlockAlignedRange(block_size, offset, length):
     return (lower, upper)
 
 
-def buildHeader(len, major=metadata.MD_MAJOR, minor=metadata.MD_MINOR):
-    # build the header, which is the first sector
-    output = ("%s%s%s%s%s%s%s" % (metadata.HDR_STRING,
-                                   HEADER_SEP,
-                                   LEN_FMT,
-                                   HEADER_SEP,
-                                   str(major),
-                                   HEADER_SEP,
-                                   str(minor)
-                                   )) % len
-    return output
+def buildHeader(length, major=metadata.MD_MAJOR, minor=metadata.MD_MINOR):
+    len_fmt = "%%-%ds" % MAX_METADATA_LENGTH_SIZE
+    return (metadata.HDR_STRING
+            + HEADER_SEP
+            + (len_fmt % length)
+            + HEADER_SEP
+            + str(major)
+            + HEADER_SEP
+            + str(minor))
 
 
 def unpackHeader(header):
@@ -159,12 +168,12 @@ def unpackHeader(header):
     return (vals[0], vals[1], vals[2], vals[3])
 
 
-def getSector(str):
-    sector = SECTOR_STRUCT % str
-    return sector
+def getSector(s):
+    sector_fmt = "%%-%ds" % SECTOR_SIZE
+    return sector_fmt % s
 
 
-def getSectorAlignedXML(tagName, value):
+def buildXMLSector(tagName, value):
     # truncate data if we breach the 512 limit
     if len("<%s>%s</%s>" % (tagName, value, tagName)) > SECTOR_SIZE:
         length = util.unictrunc(value, SECTOR_SIZE - 2 * len(tagName) - 5)
@@ -172,24 +181,35 @@ def getSectorAlignedXML(tagName, value):
                 + str(len(value)) + ' to ' + str(length) + ' bytes')
         value = value[:length]
 
-    return "<%s>%s</%s>" % (tagName, value, tagName)
+    return getSector("<%s>%s</%s>" % (tagName, value, tagName))
 
 
-def getXMLTag(tagName):
-    return "<%s>%s</%s>" % (tagName, '%s', tagName)
+def buildXMLElement(tag, value_dict):
+    return "<%s>%s</%s>" % (tag, value_dict[tag], tag)
+
+
+def openingTag(tag):
+    return "<%s>" % tag
+
+
+def closingTag(tag):
+    return "</%s>" % tag
+
+
+def buildParsableMetadataXML(info):
+    tag = metadata.XML_TAG
+    return "%s<%s>%s</%s>" % (XML_HEADER, tag, info, tag)
 
 
 def updateLengthInHeader(fd, length, major=metadata.MD_MAJOR, \
                          minor=metadata.MD_MINOR):
     try:
-        min_block_size = get_min_blk_size_wrapper(fd)
-        md = ''
-        md = file_read_wrapper(fd, 0, min_block_size, min_block_size)
+        md = file_read_wrapper(fd, 0)
         updated_md = buildHeader(length, major, minor)
         updated_md += md[SECTOR_SIZE:]
 
         # Now write the new length
-        file_write_wrapper(fd, 0, min_block_size, updated_md, len(updated_md))
+        file_write_wrapper(fd, 0, updated_md)
     except Exception as e:
         util.SMlog("Exception updating metadata length with length: %d."
                    "Error: %s" % (length, str(e)))
@@ -198,9 +218,8 @@ def updateLengthInHeader(fd, length, major=metadata.MD_MAJOR, \
 
 def getMetadataLength(fd):
     try:
-        min_blk_size = get_min_blk_size_wrapper(fd)
         sector1 = \
-            file_read_wrapper(fd, 0, SECTOR_SIZE, min_blk_size).strip()
+            file_read_wrapper(fd, 0, SECTOR_SIZE).strip()
         hdr = unpackHeader(sector1)
         len = int(hdr[1])
         return len
@@ -226,6 +245,10 @@ class MetadataHandler:
     def __del__(self):
         if self.fd:
             self.fd.close()
+
+    @property
+    def vdi_info_size(self):
+        return self.VDI_INFO_SIZE_IN_SECTORS * SECTOR_SIZE
 
     def spaceAvailableForVdis(self, count):
         raise NotImplementedError("spaceAvailableForVdis is undefined")
@@ -353,10 +376,9 @@ class MetadataHandler:
 
             try:
                 mdlength = getMetadataLength(self.fd)
-                if (mdlength - md['offset']) == \
-                    self.VDI_INFO_SIZE_IN_SECTORS * SECTOR_SIZE:
-                    updateLengthInHeader(self.fd, (mdlength - \
-                                    self.VDI_INFO_SIZE_IN_SECTORS * SECTOR_SIZE))
+                if (mdlength - md['offset']) == self.vdi_info_size:
+                    updateLengthInHeader(self.fd,
+                                         mdlength - self.vdi_info_size)
             except:
                 raise
         except Exception as e:
@@ -393,16 +415,13 @@ class MetadataHandler:
     def addVdiInternal(self, Dict):
         util.SMlog("Entering addVdiInternal")
         try:
-            value = ''
             Dict[VDI_DELETED_TAG] = '0'
-            min_block_size = get_min_blk_size_wrapper(self.fd)
             mdlength = getMetadataLength(self.fd)
             md = self.getMetadataInternal({'firstDeleted': 1, 'includeDeletedVdis': 1})
             if 'foundDeleted' not in md:
                 md['offset'] = mdlength
                 (md['lower'], md['upper']) = \
-                    getBlockAlignedRange(min_block_size, mdlength, \
-                                        SECTOR_SIZE * self.VDI_INFO_SIZE_IN_SECTORS)
+                    getBlockAlignedRange(mdlength, self.vdi_info_size)
             # If this has created a new VDI, update metadata length
             if 'foundDeleted' in md:
                 value = self.getMetadataToWrite(md['sr_info'], md['vdi_info'], \
@@ -411,14 +430,12 @@ class MetadataHandler:
                 value = self.getMetadataToWrite(md['sr_info'], md['vdi_info'], \
                         md['lower'], md['upper'], Dict, mdlength)
 
-            file_write_wrapper(self.fd, md['lower'], min_block_size, \
-                                  value, len(value))
+            file_write_wrapper(self.fd, md['lower'], value)
 
             if 'foundDeleted' in md:
                 updateLengthInHeader(self.fd, mdlength)
             else:
-                updateLengthInHeader(self.fd, mdlength + \
-                        SECTOR_SIZE * self.VDI_INFO_SIZE_IN_SECTORS)
+                updateLengthInHeader(self.fd, mdlength + self.vdi_info_size)
             return True
         except Exception as e:
             util.SMlog("Exception adding vdi with info: %s. Error: %s" % \
@@ -445,11 +462,9 @@ class MetadataHandler:
             sr_info_map = {}
             ret_vdi_info = {}
             length = getMetadataLength(self.fd)
-            min_blk_size = get_min_blk_size_wrapper(self.fd)
 
             # Read in the metadata fil
-            metadataxml = ''
-            metadataxml = file_read_wrapper(self.fd, 0, length, min_blk_size)
+            metadataxml = file_read_wrapper(self.fd, 0, length)
 
             # At this point we have the complete metadata in metadataxml
             offset = SECTOR_SIZE + len(XML_HEADER)
@@ -457,31 +472,26 @@ class MetadataHandler:
             offset = SECTOR_SIZE * 4
             sr_info = sr_info.replace('\x00', '')
 
-            parsable_metadata = '%s<%s>%s</%s>' % (XML_HEADER, metadata.XML_TAG,
-                                                   sr_info, metadata.XML_TAG)
+            parsable_metadata = buildParsableMetadataXML(sr_info)
             retmap['sr_info'] = metadata._parseXML(parsable_metadata)
 
             # At this point we check if an offset has been passed in
             if 'offset' in params:
-                upper = getBlockAlignedRange(min_blk_size, params['offset'], \
-                                             0)[1]
+                upper = getBlockAlignedRange(params['offset'], 0)[1]
             else:
                 upper = length
 
             # Now look at the VDI objects
             while offset < upper:
-                vdi_info = metadataxml[offset:
-                                offset +
-                                (SECTOR_SIZE * self.VDI_INFO_SIZE_IN_SECTORS)]
+                vdi_info = metadataxml[offset:offset + self.vdi_info_size]
                 vdi_info = vdi_info.replace('\x00', '')
-                parsable_metadata = '%s<%s>%s</%s>' % (XML_HEADER, metadata.XML_TAG,
-                                               vdi_info, metadata.XML_TAG)
+                parsable_metadata = buildParsableMetadataXML(vdi_info)
                 vdi_info_map = metadata._parseXML(parsable_metadata)[VDI_TAG]
                 vdi_info_map[OFFSET_TAG] = offset
 
                 if 'includeDeletedVdis' not in params and \
                     vdi_info_map[VDI_DELETED_TAG] == '1':
-                    offset += SECTOR_SIZE * self.VDI_INFO_SIZE_IN_SECTORS
+                    offset += self.vdi_info_size
                     continue
 
                 if 'indexByUuid' in params:
@@ -493,18 +503,16 @@ class MetadataHandler:
                     if vdi_info_map[UUID_TAG] == params['vdi_uuid']:
                         retmap['offset'] = offset
                         (lower, upper) = \
-                            getBlockAlignedRange(min_blk_size, offset, \
-                                        SECTOR_SIZE * self.VDI_INFO_SIZE_IN_SECTORS)
+                            getBlockAlignedRange(offset, self.vdi_info_size)
 
                 elif 'firstDeleted' in params:
                     if vdi_info_map[VDI_DELETED_TAG] == '1':
                         retmap['foundDeleted'] = 1
                         retmap['offset'] = offset
                         (lower, upper) = \
-                            getBlockAlignedRange(min_blk_size, offset, \
-                                        SECTOR_SIZE * self.VDI_INFO_SIZE_IN_SECTORS)
+                            getBlockAlignedRange(offset, self.vdi_info_size)
 
-                offset += SECTOR_SIZE * self.VDI_INFO_SIZE_IN_SECTORS
+                offset += self.vdi_info_size
 
             retmap['lower'] = lower
             retmap['upper'] = upper
@@ -526,8 +534,7 @@ class MetadataHandler:
         diff = set(Dict.keys()) - set(ATOMIC_UPDATE_PARAMS_AND_OFFSET.keys())
         if diff == set([]):
             offset = SECTOR_SIZE * 2
-            (lower, upper) = getBlockAlignedRange(get_min_blk_size_wrapper( \
-                self.fd), offset, SECTOR_SIZE * 2)
+            (lower, upper) = getBlockAlignedRange(offset, SECTOR_SIZE * 2)
             md = self.getMetadataInternal({'offset': \
                                 SECTOR_SIZE * (SR_INFO_SIZE_IN_SECTORS - 1)})
 
@@ -555,8 +562,7 @@ class MetadataHandler:
                 # generate the remaining VDI
                 value += self.generateVDIsForRange(vdi_info_by_offset, lower, upper)
 
-            file_write_wrapper(self.fd, lower, \
-                get_min_blk_size_wrapper(self.fd), value, len(value))
+            file_write_wrapper(self.fd, lower, value)
         else:
             raise Exception("SR Update operation not supported for "
                             "parameters: %s" % diff)
@@ -564,13 +570,11 @@ class MetadataHandler:
     def updateVdi(self, Dict):
         util.SMlog('entering updateVdi')
         try:
-            value = ''
-            min_block_size = get_min_blk_size_wrapper(self.fd)
             mdlength = getMetadataLength(self.fd)
             md = self.getMetadataInternal({'vdi_uuid': Dict[UUID_TAG]})
             value = self.getMetadataToWrite(md['sr_info'], md['vdi_info'], \
                         md['lower'], md['upper'], Dict, md['offset'])
-            file_write_wrapper(self.fd, md['lower'], min_block_size, value, len(value))
+            file_write_wrapper(self.fd, md['lower'], value)
             return True
         except Exception as e:
             util.SMlog("Exception updating vdi with info: %s. Error: %s" % \
@@ -582,7 +586,6 @@ class MetadataHandler:
     # about the SRs and all its VDIs
     def writeMetadataInternal(self, sr_info, vdi_info):
         try:
-            md = ''
             md = self.getSRInfoForSectors(sr_info, range(0, SR_INFO_SIZE_IN_SECTORS))
 
             # Go over the VDIs passed and for each
@@ -590,8 +593,7 @@ class MetadataHandler:
                 md += self.getVdiInfo(vdi_info[key])
 
             # Now write the metadata on disk.
-            min_block_size = get_min_blk_size_wrapper(self.fd)
-            file_write_wrapper(self.fd, 0, min_block_size, md, len(md))
+            file_write_wrapper(self.fd, 0, md)
             updateLengthInHeader(self.fd, len(md))
 
         except Exception as e:
@@ -720,8 +722,10 @@ class LVMMetadataHandler(MetadataHandler):
                                 Dict[NAME_DESCRIPTION_TAG][:length]
 
                 # Fill the open struct and write it
-                vdi_info += getSector(VDI_SECTOR_1 % (Dict[NAME_LABEL_TAG],
-                                                      Dict[NAME_DESCRIPTION_TAG]))
+                vdi_info += getSector(openingTag(VDI_TAG)
+                                      + buildXMLElement(NAME_LABEL_TAG, Dict)
+                                      + buildXMLElement(NAME_DESCRIPTION_TAG,
+                                                        Dict))
 
             if generateSector == 2 or generateSector == 0:
                 sector2 = ''
@@ -732,9 +736,9 @@ class LVMMetadataHandler(MetadataHandler):
                 for tag in Dict.keys():
                     if tag == NAME_LABEL_TAG or tag == NAME_DESCRIPTION_TAG:
                         continue
-                    sector2 += getXMLTag(tag) % Dict[tag]
+                    sector2 += buildXMLElement(tag, Dict)
 
-                sector2 += VDI_CLOSING_TAG
+                sector2 += closingTag(VDI_TAG)
                 vdi_info += getSector(sector2)
             return vdi_info
 
@@ -754,21 +758,19 @@ class LVMMetadataHandler(MetadataHandler):
                 srinfo = getSector(buildHeader(SECTOR_SIZE))
 
             if 1 in range:
-                uuid = getXMLTag(UUID_TAG) % sr_info[UUID_TAG]
-                allocation = getXMLTag(ALLOCATION_TAG) % sr_info[ALLOCATION_TAG]
-
-                second = SECTOR2_FMT % (XML_HEADER, uuid, allocation)
-                srinfo += getSector(second)
+                srinfo += getSector(XML_HEADER
+                                    + buildXMLElement(UUID_TAG, sr_info)
+                                    + buildXMLElement(ALLOCATION_TAG, sr_info))
 
             if 2 in range:
                 # Fill up the SR name_label
-                srinfo += getSector(getSectorAlignedXML(NAME_LABEL_TAG,
-                    xml.sax.saxutils.escape(sr_info[NAME_LABEL_TAG])))
+                srinfo += buildXMLSector(NAME_LABEL_TAG,
+                    xml.sax.saxutils.escape(sr_info[NAME_LABEL_TAG]))
 
             if 3 in range:
                 # Fill the name_description
-                srinfo += getSector(getSectorAlignedXML(NAME_DESCRIPTION_TAG,
-                    xml.sax.saxutils.escape(sr_info[NAME_DESCRIPTION_TAG])))
+                srinfo += buildXMLSector(NAME_DESCRIPTION_TAG,
+                    xml.sax.saxutils.escape(sr_info[NAME_DESCRIPTION_TAG]))
 
             return srinfo
 

--- a/drivers/srmetadata.py
+++ b/drivers/srmetadata.py
@@ -36,7 +36,7 @@ import xml.sax.saxutils
 # potentially be reused when a new VDI is subsequently added.
 
 SECTOR_SIZE = 512
-XML_HEADER = "<?xml version=\"1.0\" ?>"
+XML_HEADER = b"<?xml version=\"1.0\" ?>"
 MAX_METADATA_LENGTH_SIZE = 10
 OFFSET_TAG = 'offset'
 
@@ -100,13 +100,12 @@ def file_write_wrapper(fd, offset, data):
         if length % blocksize:
             newlength = length + (blocksize - length % blocksize)
         fd.seek(offset, SEEK_SET)
-        to_write = data + ' ' * (newlength - length)
-        result = fd.write(to_write.encode())
+        to_write = data + b' ' * (newlength - length)
+        return fd.write(to_write)
     except OSError as e:
         raise OSError(
             "Failed to write file with params %s. Error: %s" %
             ([fd, offset, blocksize, data], e.errno))
-    return result
 
 
 # Reads data from a file at a given offset. If not specified, the amount of
@@ -114,12 +113,28 @@ def file_write_wrapper(fd, offset, data):
 def file_read_wrapper(fd, offset, bytesToRead=METADATA_BLK_SIZE):
     try:
         fd.seek(offset, SEEK_SET)
-        result = fd.read(bytesToRead)
+        return fd.read(bytesToRead)
     except OSError as e:
         raise OSError(
             "Failed to read file with params %s. Error: %s" %
             ([fd, offset, bytesToRead], e.errno))
-    return result.decode()
+
+
+# String data in this module takes the form of normal Python unicode `str`
+# instances, or UTF-8 encoded `bytes`, depending on circumstance. In `dict`
+# instances such as are used to represent SR and VDI info, `str` is used (as
+# these may be returned to, or have been supplied by, this module's callers).
+# Data going into or taken from a metadata file is `bytes`. XML and XML
+# fragments come under this category, so are `bytes`. XML tag names are `str`
+# instances, as these are also used as `dict` keys.
+
+
+def to_utf8(s):
+    return s.encode("utf-8")
+
+
+def from_utf8(bs):
+    return bs.decode("utf-8")
 
 
 # get a range which is block aligned, contains 'offset' and allows
@@ -149,17 +164,17 @@ def getBlockAlignedRange(offset, length):
 
 def buildHeader(length, major=metadata.MD_MAJOR, minor=metadata.MD_MINOR):
     len_fmt = "%%-%ds" % MAX_METADATA_LENGTH_SIZE
-    return (metadata.HDR_STRING
-            + HEADER_SEP
-            + (len_fmt % length)
-            + HEADER_SEP
-            + str(major)
-            + HEADER_SEP
-            + str(minor))
+    return to_utf8(metadata.HDR_STRING
+                   + HEADER_SEP
+                   + (len_fmt % length)
+                   + HEADER_SEP
+                   + str(major)
+                   + HEADER_SEP
+                   + str(minor))
 
 
 def unpackHeader(header):
-    vals = header.split(HEADER_SEP)
+    vals = from_utf8(header).split(HEADER_SEP)
     if len(vals) != 4 or vals[0] != metadata.HDR_STRING:
         util.SMlog("Exception unpacking metadata header: "
                    "Error: Bad header '%s'" % (header))
@@ -169,36 +184,40 @@ def unpackHeader(header):
 
 
 def getSector(s):
-    sector_fmt = "%%-%ds" % SECTOR_SIZE
+    sector_fmt = b"%%-%ds" % SECTOR_SIZE
     return sector_fmt % s
 
 
 def buildXMLSector(tagName, value):
     # truncate data if we breach the 512 limit
-    if len("<%s>%s</%s>" % (tagName, value, tagName)) > SECTOR_SIZE:
-        length = util.unictrunc(value, SECTOR_SIZE - 2 * len(tagName) - 5)
-        util.SMlog('warning: SR ' + tagName + ' truncated from ' \
-                + str(len(value)) + ' to ' + str(length) + ' bytes')
-        value = value[:length]
+    tag_bytes = to_utf8(tagName)
+    value_bytes = to_utf8(value)
 
-    return getSector("<%s>%s</%s>" % (tagName, value, tagName))
+    elt = b"<%s>%s</%s>" % (tag_bytes, value_bytes, tag_bytes)
+    if len(elt) > SECTOR_SIZE:
+        length = util.unictrunc(value_bytes, SECTOR_SIZE - 2 * len(tag_bytes) - 5)
+        util.SMlog('warning: SR %s truncated from %d to %d bytes'
+                   % (tagName, len(value_bytes), length))
+        elt = b"<%s>%s</%s>" % (tag_bytes, value_bytes[:length], tag_bytes)
+
+    return getSector(elt)
 
 
 def buildXMLElement(tag, value_dict):
-    return "<%s>%s</%s>" % (tag, value_dict[tag], tag)
+    return to_utf8("<%s>%s</%s>" % (tag, value_dict[tag], tag))
 
 
 def openingTag(tag):
-    return "<%s>" % tag
+    return b"<%s>" % to_utf8(tag)
 
 
 def closingTag(tag):
-    return "</%s>" % tag
+    return b"</%s>" % to_utf8(tag)
 
 
 def buildParsableMetadataXML(info):
-    tag = metadata.XML_TAG
-    return "%s<%s>%s</%s>" % (XML_HEADER, tag, info, tag)
+    tag = to_utf8(metadata.XML_TAG)
+    return b"%s<%s>%s</%s>" % (XML_HEADER, tag, info, tag)
 
 
 def updateLengthInHeader(fd, length, major=metadata.MD_MAJOR, \
@@ -221,8 +240,7 @@ def getMetadataLength(fd):
         sector1 = \
             file_read_wrapper(fd, 0, SECTOR_SIZE).strip()
         hdr = unpackHeader(sector1)
-        len = int(hdr[1])
-        return len
+        return int(hdr[1])
     except Exception as e:
         util.SMlog("Exception getting metadata length: "
                    "Error: %s" % str(e))
@@ -389,10 +407,10 @@ class MetadataHandler:
     # common functions with some details derived from the child class
     def generateVDIsForRange(self, vdi_info, lower, upper, update_map={}, \
                              offset=0):
-        value = ''
         if not len(vdi_info.keys()) or offset not in vdi_info:
             return self.getVdiInfo(update_map)
 
+        value = b""
         for vdi_offset in vdi_info.keys():
             if vdi_offset < lower:
                 continue
@@ -470,7 +488,7 @@ class MetadataHandler:
             offset = SECTOR_SIZE + len(XML_HEADER)
             sr_info = metadataxml[offset: SECTOR_SIZE * 4]
             offset = SECTOR_SIZE * 4
-            sr_info = sr_info.replace('\x00', '')
+            sr_info = sr_info.replace(b'\x00', b'')
 
             parsable_metadata = buildParsableMetadataXML(sr_info)
             retmap['sr_info'] = metadata._parseXML(parsable_metadata)
@@ -484,7 +502,7 @@ class MetadataHandler:
             # Now look at the VDI objects
             while offset < upper:
                 vdi_info = metadataxml[offset:offset + self.vdi_info_size]
-                vdi_info = vdi_info.replace('\x00', '')
+                vdi_info = vdi_info.replace(b'\x00', b'')
                 parsable_metadata = buildParsableMetadataXML(vdi_info)
                 vdi_info_map = metadata._parseXML(parsable_metadata)[VDI_TAG]
                 vdi_info_map[OFFSET_TAG] = offset
@@ -528,7 +546,7 @@ class MetadataHandler:
     def updateSR(self, Dict):
         util.SMlog('entering updateSR')
 
-        value = ''
+        value = b""
 
         # Find the offset depending on what we are updating
         diff = set(Dict.keys()) - set(ATOMIC_UPDATE_PARAMS_AND_OFFSET.keys())
@@ -610,7 +628,7 @@ class MetadataHandler:
                            offset):
         util.SMlog("Entering getMetadataToWrite")
         try:
-            value = ''
+            value = b""
             vdi_map = {}
 
             # if lower is less than SR info
@@ -636,10 +654,10 @@ class MetadataHandler:
 
     # specific functions, to be implement by the child classes
     def getVdiInfo(self, Dict, generateSector=0):
-        return ''
+        return b""
 
     def getSRInfoForSectors(self, sr_info, range):
-        return ''
+        return b""
 
 
 class LVMMetadataHandler(MetadataHandler):
@@ -686,40 +704,32 @@ class LVMMetadataHandler(MetadataHandler):
     def getVdiInfo(self, Dict, generateSector=0):
         util.SMlog("Entering VDI info")
         try:
-            vdi_info = ''
+            vdi_info = b""
             # HP split into 2 functions, 1 for generating the first 2 sectors,
             # which will be called by all classes
             # and one specific to this class
             if generateSector == 1 or generateSector == 0:
-                Dict[NAME_LABEL_TAG] = \
-                        xml.sax.saxutils.escape(Dict[NAME_LABEL_TAG])
-                Dict[NAME_DESCRIPTION_TAG] = \
-                        xml.sax.saxutils.escape(Dict[NAME_DESCRIPTION_TAG])
-                if len(Dict[NAME_LABEL_TAG]) + len(Dict[NAME_DESCRIPTION_TAG]) > \
-                        MAX_VDI_NAME_LABEL_DESC_LENGTH:
-                    if len(Dict[NAME_LABEL_TAG]) > MAX_VDI_NAME_LABEL_DESC_LENGTH // 2:
-                        length = util.unictrunc(
-                            Dict[NAME_LABEL_TAG],
-                            MAX_VDI_NAME_LABEL_DESC_LENGTH // 2)
+                label = xml.sax.saxutils.escape(Dict[NAME_LABEL_TAG])
+                desc = xml.sax.saxutils.escape(Dict[NAME_DESCRIPTION_TAG])
+                label_length = len(to_utf8(label))
+                desc_length = len(to_utf8(desc))
 
-                        util.SMlog('warning: name-label truncated from ' +
-                                   str(len(Dict[NAME_LABEL_TAG])) + ' to ' +
-                                   str(length) + ' bytes')
+                if label_length + desc_length > MAX_VDI_NAME_LABEL_DESC_LENGTH:
+                    limit = MAX_VDI_NAME_LABEL_DESC_LENGTH // 2
+                    if label_length > limit:
+                        label = label[:util.unictrunc(label, limit)]
+                        util.SMlog('warning: name-label truncated from '
+                                   '%d to %d bytes'
+                                   % (label_length, len(to_utf8(label))))
 
-                        Dict[NAME_LABEL_TAG] = Dict[NAME_LABEL_TAG][:length]
+                    if desc_length > limit:
+                        desc = desc[:util.unictrunc(desc, limit)]
+                        util.SMlog('warning: description truncated from '
+                                   '%d to %d bytes'
+                                   % (desc_length, len(to_utf8(desc))))
 
-                    if (len(Dict[NAME_DESCRIPTION_TAG]) >
-                            MAX_VDI_NAME_LABEL_DESC_LENGTH // 2):
-                        length = util.unictrunc(
-                            Dict[NAME_DESCRIPTION_TAG],
-                            MAX_VDI_NAME_LABEL_DESC_LENGTH // 2)
-
-                        util.SMlog('warning: description truncated from ' +
-                                   str(len(Dict[NAME_DESCRIPTION_TAG])) +
-                                   ' to ' + str(length) + ' bytes')
-
-                        Dict[NAME_DESCRIPTION_TAG] = \
-                                Dict[NAME_DESCRIPTION_TAG][:length]
+                Dict[NAME_LABEL_TAG] = label
+                Dict[NAME_DESCRIPTION_TAG] = desc
 
                 # Fill the open struct and write it
                 vdi_info += getSector(openingTag(VDI_TAG)
@@ -728,7 +738,7 @@ class LVMMetadataHandler(MetadataHandler):
                                                         Dict))
 
             if generateSector == 2 or generateSector == 0:
-                sector2 = ''
+                sector2 = b""
 
                 if VDI_DELETED_TAG not in Dict:
                     Dict.update({VDI_DELETED_TAG: '0'})
@@ -748,7 +758,7 @@ class LVMMetadataHandler(MetadataHandler):
             raise
 
     def getSRInfoForSectors(self, sr_info, range):
-        srinfo = ''
+        srinfo = b""
 
         try:
             # write header, name_labael and description in that function

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1737,7 +1737,6 @@ def unictrunc(string, max_bytes):
     string: the string to truncate
     max_bytes: the maximum number of bytes the truncated string can be
     """
-    string = string.decode('UTF-8')
     cur_bytes = 0
     for char in string:
         charsize = len(char.encode('UTF-8'))

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1731,20 +1731,35 @@ def isLegalXMLString(s):
 
 def unictrunc(string, max_bytes):
     """
-    Returns the number of bytes that is smaller than, or equal to, the number
-    of bytes specified, such that the UTF-8 encoded string can be correctly
-    truncated.
+    Given a string, returns the largest number of elements for a prefix
+    substring of it, such that the UTF-8 encoding of this substring takes no
+    more than the given number of bytes.
+
+    The string may be given as a unicode string or a UTF-8 encoded byte
+    string, and the number returned will be in characters or bytes
+    accordingly.  Note that in the latter case, the substring will still be a
+    valid UTF-8 encoded string (which is to say, it won't have been truncated
+    part way through a multibyte sequence for a unicode character).
+
     string: the string to truncate
     max_bytes: the maximum number of bytes the truncated string can be
     """
+    if isinstance(string, str):
+        return_chars = True
+    else:
+        return_chars = False
+        string = string.decode('UTF-8')
+
+    cur_chars = 0
     cur_bytes = 0
     for char in string:
         charsize = len(char.encode('UTF-8'))
         if cur_bytes + charsize > max_bytes:
             break
         else:
-            cur_bytes = cur_bytes + charsize
-    return cur_bytes
+            cur_chars += 1
+            cur_bytes += charsize
+    return cur_chars if return_chars else cur_bytes
 
 
 def hideValuesInPropMap(propmap, propnames):

--- a/tests/test_SRCommand.py
+++ b/tests/test_SRCommand.py
@@ -121,3 +121,52 @@ class TestStandaloneFunctions(unittest.TestCase):
         mock_driver = mock.Mock(side_effect=SomeException)
 
         SRCommand.run(mock_driver, DRIVER_INFO)
+
+    @mock.patch("os.fsencode",
+                new=lambda s: s.encode("ascii", "surrogateescape"))
+    @mock.patch("os.fsdecode",
+                new=lambda bs: bs.decode("ascii", "surrogateescape"))
+    def test_parse_handles_wide_chars(self):
+        import os
+        import xmlrpc.client
+        from DummySR import DRIVER_INFO
+
+        xmlrpc_method = "vdi_create"
+        xmlrpc_params = {
+            'host_ref': 'OpaqueRef:133c7c46-f4d9-3695-83c4-bf8574b89fb9',
+            'command': 'vdi_create',
+            'args': [
+                '10737418240',
+                '\u4e2d\u6587\u673a\u5668 0',
+                'Created by template provisioner',
+                '',
+                'false',
+                '19700101T00:00:00Z',
+                '',
+                'false'
+            ],
+            'device_config': {
+                'SRmaster': 'true',
+                'device': '/dev/disk/by-id/scsi-3600508b1001c25e9eea8ead175fd83fb-part3'
+            },
+            'session_ref': 'OpaqueRef:c2c628b6-93c3-5e29-00cf-4f15a34e1555',
+            'sr_ref': 'OpaqueRef:c523a79a-8a60-121c-832e-d507586cb117',
+            'vdi_type': 'system',
+            'sr_uuid': '13c4384e-897b-e745-6b3e-9a89c06537be',
+            'vdi_sm_config': {},
+            'subtask_of': 'DummyRef:|0c533c65-d321-59c2-f540c-e66efbe3b1b7|VDI.create'
+        }
+
+        # We are trying to simulate how a UTF8-encoded request passed on the
+        # command line shows up in sys.argv. FS encoding always makes use of
+        # "surrogateescape" (see https://peps.python.org/pep-0383/) but the
+        # actual encoding would probably depend on locale settings.
+
+        request = xmlrpc.client.dumps((xmlrpc_params,), xmlrpc_method)
+        argv = ["foo.py", os.fsdecode(request.encode("utf-8"))]
+        with mock.patch("sys.argv", new=argv):
+            srcommand = SRCommand.SRCommand(DRIVER_INFO)
+            srcommand.parse()
+
+            self.assertEqual(srcommand.cmd, xmlrpc_method)
+            self.assertEqual(srcommand.params, xmlrpc_params)

--- a/tests/test_srmetadata.py
+++ b/tests/test_srmetadata.py
@@ -14,7 +14,7 @@ from srmetadata import (LVMMetadataHandler, buildHeader, buildXMLSector,
 class TestSRMetadataFunctions(unittest.TestCase):
     def test_unpackHeader(self):
         # Given
-        header = "XSSM:4096      :1:2" + (' ' * 493)
+        header = b"XSSM:4096      :1:2" + (b' ' * 493)
 
         # When
         hdr_string, length, major, minor = unpackHeader(header)
@@ -54,9 +54,9 @@ class TestSRMetadataFunctions(unittest.TestCase):
         xml3 = buildXMLSector(tag_name, value3)
 
         # Then
-        self.assertEqual(xml1, "<blah>%s</blah>" % value1)
+        self.assertEqual(xml1.decode("utf8"), "<blah>%s</blah>" % value1)
         self.assertEqual(xml2, xml1)
-        self.assertEqual(xml3,
+        self.assertEqual(xml3.decode("utf8"),
                          "<blah>%s</blah>" % value3 + " " * value3_deficit)
 
     def test_getMetadataLength(self):
@@ -310,9 +310,8 @@ class TestLVMMetadataHandler(unittest.TestCase):
         self.assertEqual(set(retrieved_description), set(vdi3_description))
         self.assertLess(len(retrieved_description), len(vdi3_description))
 
-    @unittest.expectedFailure
     @with_lvm_test_context
-    def test_long_non_ascii_names_truncated(self): # pragma: no cover
+    def test_long_non_ascii_names_truncated(self):
         # Given
         self.make_handler().writeMetadata(self.make_sr_info(), {})
 
@@ -354,7 +353,6 @@ class TestLVMMetadataHandler(unittest.TestCase):
         self.assertEqual(set(retrieved_description), set(vdi2_description))
         self.assertLess(len(retrieved_description), len(vdi2_description))
 
-    @unittest.expectedFailure
     @with_lvm_test_context
     def test_CA383791(self):
         # Given
@@ -369,7 +367,7 @@ class TestLVMMetadataHandler(unittest.TestCase):
         caught = None
         try:
             self.make_handler().ensureSpaceIsAvailableForVdis(1)
-        except Exception as e:
+        except Exception as e: # pragma: no cover
             caught = e
 
         # Then
@@ -466,7 +464,7 @@ class LVMMetadataTestContext(testlib.TestContext):
         yield self.METADATA_PATH
 
     def fake_open(self, fname, mode='r'):
-        if fname != self.METADATA_PATH:
+        if fname != self.METADATA_PATH: # pragma: no cover
             return super().fake_open(fname, mode)
         else:
             return LVMMetadataFile.open(self, mode)

--- a/tests/test_srmetadata.py
+++ b/tests/test_srmetadata.py
@@ -1,0 +1,508 @@
+import io
+import random
+import string
+import testlib
+import uuid
+import unittest
+import unittest.mock as mock
+
+from srmetadata import (LVMMetadataHandler, buildHeader, getMetadataLength,
+                        getSectorAlignedXML, unpackHeader,
+                        updateLengthInHeader, MAX_VDI_NAME_LABEL_DESC_LENGTH)
+
+
+class TestSRMetadataFunctions(unittest.TestCase):
+    def test_unpackHeader(self):
+        # Given
+        header = "XSSM:4096      :1:2" + (' ' * 493)
+
+        # When
+        hdr_string, length, major, minor = unpackHeader(header)
+
+        # Then
+        self.assertEqual(hdr_string, "XSSM")
+        self.assertEqual(int(length), 4096)
+        self.assertEqual(int(major), 1)
+        self.assertEqual(int(minor), 2)
+
+    def test_buildHeader_unpackHeader_roundTrip(self):
+        # Given
+        orig_length = 12345
+        orig_major = 67
+        orig_minor = 89
+
+        # When
+        header = buildHeader(orig_length, orig_major, orig_minor)
+        _, length, major, minor = unpackHeader(header)
+
+        # Then
+        self.assertEqual(int(length), orig_length)
+        self.assertEqual(int(major), orig_major)
+        self.assertEqual(int(minor), orig_minor)
+
+    def test_getSectorAlignedXML(self):
+        # Given
+        tag_name = "blah"
+        value1 = "x" * (512 - len("<blah>") - len("</blah>"))
+        value2 = value1 + "excess"
+
+        # When
+        xml1 = getSectorAlignedXML(tag_name, value1)
+        xml2 = getSectorAlignedXML(tag_name, value2)
+
+        # Then
+        self.assertEqual(xml1, "<blah>%s</blah>" % value1)
+        self.assertEqual(xml2, xml1)
+
+    def test_getMetadataLength(self):
+        # Given
+        f = io.BytesIO(b"XSSM:9876      :5:4" + (b' ' * 493))
+
+        # When
+        length = getMetadataLength(f)
+
+        # Then
+        self.assertEqual(length, 9876)
+
+    def test_updateLengthInHeader_getMetadataLength_roundtrip(self):
+        # Given
+        f = io.BytesIO(b"XSSM:4096      :1:2" + (b' ' * 493) + b"etc etc")
+
+        # When
+        updateLengthInHeader(f, 90210)
+        length = getMetadataLength(f)
+
+        # Then
+        self.assertEqual(length, 90210)
+        self.assertEqual(f.getvalue()[512:], b"etc etc")
+
+
+def with_lvm_test_context(func):
+    def decorated(self, *args, **kwargs):
+        context = LVMMetadataTestContext()
+        context.start()
+        self.context = context
+        try:
+            return func(self, *args, **kwargs)
+        finally:
+            context.stop()
+
+    decorated.__name__ = func.__name__
+    return decorated
+
+
+class TestLVMMetadataHandler(unittest.TestCase):
+    @with_lvm_test_context
+    def test_writeMetadata_getMetadata_roundtrip(self):
+        # Given
+        vdi1_uuid = genuuid()
+        vdi2_uuid = genuuid()
+
+        orig_sr_info = self.make_sr_info()
+
+        orig_vdi_info = {
+            vdi1_uuid: self.make_vdi_info(vdi1_uuid),
+            vdi2_uuid: self.make_vdi_info(vdi2_uuid),
+        }
+
+        # When
+        self.make_handler().writeMetadata(orig_sr_info, orig_vdi_info)
+        sr_info, vdi_info = self.make_handler(False).getMetadata()
+
+        # Then
+        self.assertEqual(sr_info, orig_sr_info)
+        self.assertVdiInfoEqual(vdi_info, orig_vdi_info)
+
+    @with_lvm_test_context
+    def test_addVdi(self):
+        # Given
+        existing_vdi_uuid = genuuid()
+        initial_vdi_info = {
+            existing_vdi_uuid: self.make_vdi_info(existing_vdi_uuid)
+        }
+
+        self.make_handler().writeMetadata(self.make_sr_info(),
+                                          initial_vdi_info)
+
+        new_vdi_uuid = genuuid()
+        new_vdi_info = self.make_vdi_info(new_vdi_uuid)
+        expected_resultant_vdi_info = {
+            **initial_vdi_info,
+            new_vdi_uuid: new_vdi_info
+        }
+
+        # When
+        self.make_handler().addVdi(new_vdi_info)
+
+        # Then
+        _, vdi_info = self.make_handler(False).getMetadata()
+        self.assertVdiInfoEqual(vdi_info, expected_resultant_vdi_info)
+
+    @with_lvm_test_context
+    def test_deleteVdiFromMetadata(self):
+        # Given
+        vdi1_uuid = genuuid()
+        vdi2_uuid = genuuid()
+
+        initial_vdi_info = {
+            vdi1_uuid: self.make_vdi_info(vdi1_uuid),
+            vdi2_uuid: self.make_vdi_info(vdi2_uuid),
+        }
+
+        self.make_handler().writeMetadata(self.make_sr_info(), initial_vdi_info)
+
+        expected_resultant_vdi_info = {
+            vdi2_uuid: initial_vdi_info[vdi2_uuid]
+        }
+
+        # When
+        self.make_handler().deleteVdiFromMetadata(vdi1_uuid)
+
+        # Then
+        _, vdi_info = self.make_handler(False).getMetadata()
+        self.assertVdiInfoEqual(vdi_info, expected_resultant_vdi_info)
+
+    @with_lvm_test_context
+    def test_addVdi_reuses_deleted_slot(self):
+        # Given
+        self.make_handler().writeMetadata(self.make_sr_info(), {})
+
+        vdi1_uuid = genuuid()
+        vdi2_uuid = genuuid()
+
+        self.make_handler().addVdi(self.make_vdi_info(vdi1_uuid))
+        self.make_handler().addVdi(self.make_vdi_info(vdi2_uuid))
+
+        metadata_length = self.get_metadata_length()
+
+        # When
+        self.make_handler().deleteVdiFromMetadata(vdi1_uuid)
+        self.make_handler().addVdi(self.make_vdi_info(genuuid()))
+
+        # Then
+        self.assertEqual(self.get_metadata_length(), metadata_length)
+
+    @with_lvm_test_context
+    def test_deleteVdiFromMetadata_shinks_metadata(self):
+        # Given
+        self.make_handler().writeMetadata(self.make_sr_info(), {})
+
+        vdi1_uuid = genuuid()
+        vdi2_uuid = genuuid()
+
+        self.make_handler().addVdi(self.make_vdi_info(vdi1_uuid))
+        self.make_handler().addVdi(self.make_vdi_info(vdi2_uuid))
+
+        metadata_length = self.get_metadata_length()
+
+        # When
+        self.make_handler().deleteVdiFromMetadata(vdi2_uuid)
+
+        # Then
+        self.assertLess(self.get_metadata_length(), metadata_length)
+
+    @with_lvm_test_context
+    def test_updateMetadata_SR(self):
+        # Given
+        orig = self.make_sr_info()
+
+        self.make_handler().writeMetadata(orig, {})
+
+        new_name_label = orig["name_label"] + " updated"
+
+        # When
+        self.make_handler().updateMetadata({
+            "objtype": "sr",
+            "name_label": new_name_label
+        })
+
+        # Then
+        sr_info, _ = self.make_handler(False).getMetadata()
+        self.assertEqual(sr_info, {**orig, "name_label": new_name_label})
+
+    @with_lvm_test_context
+    def test_updateMetadata_VDI(self):
+        # Given
+        vdi1_uuid = genuuid()
+        vdi2_uuid = genuuid()
+
+        orig = self.make_vdi_info(vdi1_uuid)
+
+        initial_vdi_info = {
+            vdi1_uuid: orig,
+            vdi2_uuid: self.make_vdi_info(vdi2_uuid),
+        }
+
+        new_name_label = orig["name_label"] + " updated"
+
+        expected_resultant_vdi_info = {
+            vdi1_uuid: {**orig, "name_label": new_name_label},
+            vdi2_uuid: initial_vdi_info[vdi2_uuid]
+        }
+
+        self.make_handler().writeMetadata(self.make_sr_info(), initial_vdi_info)
+
+        # When
+        self.make_handler().updateMetadata({
+            "objtype": "vdi",
+            "uuid": vdi1_uuid,
+            "name_label": new_name_label
+        })
+
+        # Then
+        _, vdi_info = self.make_handler(False).getMetadata()
+        self.assertVdiInfoEqual(vdi_info, expected_resultant_vdi_info)
+
+    @with_lvm_test_context
+    def test_long_names_truncated(self):
+        # Given
+        self.make_handler().writeMetadata(self.make_sr_info(), {})
+
+        vdi1_uuid = genuuid()
+        vdi2_uuid = genuuid()
+        vdi3_uuid = genuuid()
+
+        vdi1_label = "1" * MAX_VDI_NAME_LABEL_DESC_LENGTH
+        vdi1_description = "x"
+
+        vdi2_label = "2"
+        vdi2_description = "y" * MAX_VDI_NAME_LABEL_DESC_LENGTH
+
+        vdi3_label = "3" * (1 + MAX_VDI_NAME_LABEL_DESC_LENGTH // 2)
+        vdi3_description = "z" * (1 + MAX_VDI_NAME_LABEL_DESC_LENGTH // 2)
+
+        # When
+        self.make_handler().addVdi(self.make_vdi_info(vdi1_uuid,
+                                                      vdi1_label,
+                                                      vdi1_description))
+        self.make_handler().addVdi(self.make_vdi_info(vdi2_uuid,
+                                                      vdi2_label,
+                                                      vdi2_description))
+        self.make_handler().addVdi(self.make_vdi_info(vdi3_uuid,
+                                                      vdi3_label,
+                                                      vdi3_description))
+
+        # Then
+        _, vdi_info = self.make_handler(False) \
+                          .getMetadata({"indexByUuid": True})
+
+        retrieved_label = vdi_info[vdi1_uuid]["name_label"]
+        retrieved_description = vdi_info[vdi1_uuid]["name_description"]
+        self.assertEqual(set(retrieved_label), set(vdi1_label))
+        self.assertLess(len(retrieved_label), len(vdi1_label))
+        self.assertEqual(retrieved_description, vdi1_description)
+
+        retrieved_label = vdi_info[vdi2_uuid]["name_label"]
+        retrieved_description = vdi_info[vdi2_uuid]["name_description"]
+        self.assertEqual(retrieved_label, vdi2_label)
+        self.assertEqual(set(retrieved_description), set(vdi2_description))
+        self.assertLess(len(retrieved_description), len(vdi2_description))
+
+        retrieved_label = vdi_info[vdi3_uuid]["name_label"]
+        retrieved_description = vdi_info[vdi3_uuid]["name_description"]
+        self.assertEqual(set(retrieved_label), set(vdi3_label))
+        self.assertLess(len(retrieved_label), len(vdi3_label))
+        self.assertEqual(set(retrieved_description), set(vdi3_description))
+        self.assertLess(len(retrieved_description), len(vdi3_description))
+
+    @unittest.expectedFailure
+    @with_lvm_test_context
+    def test_long_non_ascii_names_truncated(self): # pragma: no cover
+        # Given
+        self.make_handler().writeMetadata(self.make_sr_info(), {})
+
+        vdi1_uuid = genuuid()
+        vdi2_uuid = genuuid()
+
+        string_length = MAX_VDI_NAME_LABEL_DESC_LENGTH // 2
+
+        # Contrive to create strings that don't look too long, but only if you
+        # forget that they'll get multi-byte encodings.
+
+        vdi1_label = "\u9d5d" * (MAX_VDI_NAME_LABEL_DESC_LENGTH // 2)
+        vdi1_description = "\U0001f926"
+
+        vdi2_label = "\u232c"
+        vdi2_description = "\U0001f680" * (MAX_VDI_NAME_LABEL_DESC_LENGTH // 2)
+
+        # When
+        self.make_handler().addVdi(self.make_vdi_info(vdi1_uuid,
+                                                      vdi1_label,
+                                                      vdi1_description))
+        self.make_handler().addVdi(self.make_vdi_info(vdi2_uuid,
+                                                      vdi2_label,
+                                                      vdi2_description))
+
+        # Then
+        _, vdi_info = self.make_handler(False) \
+                          .getMetadata({"indexByUuid": True})
+
+        retrieved_label = vdi_info[vdi1_uuid]["name_label"]
+        retrieved_description = vdi_info[vdi1_uuid]["name_description"]
+        self.assertEqual(set(retrieved_label), set(vdi1_label))
+        self.assertLess(len(retrieved_label), len(vdi1_label))
+        self.assertEqual(retrieved_description, vdi1_description)
+
+        retrieved_label = vdi_info[vdi2_uuid]["name_label"]
+        retrieved_description = vdi_info[vdi2_uuid]["name_description"]
+        self.assertEqual(retrieved_label, vdi2_label)
+        self.assertEqual(set(retrieved_description), set(vdi2_description))
+        self.assertLess(len(retrieved_description), len(vdi2_description))
+
+    @unittest.expectedFailure
+    @with_lvm_test_context
+    def test_CA383791(self):
+        # Given
+        vdi_uuid = genuuid()
+
+        self.make_handler().writeMetadata(self.make_sr_info(), {})
+
+        added_vdi_info = self.make_vdi_info(vdi_uuid, "VDI \u4e2d 0")
+
+        # When
+        self.make_handler().addVdi(added_vdi_info)
+        caught = None
+        try:
+            self.make_handler().ensureSpaceIsAvailableForVdis(1)
+        except Exception as e:
+            caught = e
+
+        # Then
+        self.assertIsNone(caught)
+
+    def make_handler(self, *args):
+        return LVMMetadataHandler(self.context.METADATA_PATH, *args)
+
+    def get_metadata_length(self):
+        with open(self.context.METADATA_PATH, "rb") as f:
+            return getMetadataLength(f)
+
+    def make_sr_info(self, label="Test Storage"):
+        return {
+            "allocation": "thin",
+            "uuid": genuuid(),
+            "name_label": label,
+            "name_description": random_string(20)
+        }
+
+    def make_vdi_info(self, vdi_uuid, label=None, description=None):
+        if not label:
+            label = random_string(10)
+
+        if not description:
+            description = random_string(20)
+
+        return {
+            "uuid": vdi_uuid,
+            "name_label": label,
+            "name_description": description,
+            "is_snapshot": "0",
+            "snapshot_of": "",
+            "snapshot_time": "",
+            "type": "user",
+            "vdi_type": "vhd",
+            "read_only": "0",
+            "metadata_of_pool": "",
+            "managed": "1"
+        }
+
+    VDI_INFO_COMPARISON_FIELDS = frozenset([
+        "uuid",
+        "name_label",
+        "name_description",
+        "is_snapshot",
+        "snapshot_of",
+        "snapshot_time",
+        "type",
+        "vdi_type",
+        "read_only",
+        "metadata_of_pool",
+        "managed"
+    ])
+
+    def assertVdiInfoEqual(self, lhs_record_dict, rhs_record_dict):
+        def convert_info(record):
+            return dict((key, record[key])
+                        for key in record
+                        if key in self.VDI_INFO_COMPARISON_FIELDS)
+
+        lhs_records_by_uuid = dict((record["uuid"], convert_info(record))
+                                   for record in lhs_record_dict.values())
+        rhs_records_by_uuid = dict((record["uuid"], convert_info(record))
+                                   for record in lhs_record_dict.values())
+
+        self.assertEqual(lhs_records_by_uuid, rhs_records_by_uuid)
+
+
+def random_string(n):
+    return "".join(random.choice(string.ascii_letters)
+                   for _ in range(n))
+
+
+def genuuid():
+    return str(uuid.uuid4())
+
+
+class LVMMetadataTestContext(testlib.TestContext):
+    METADATA_PATH = "/dev/VG_XenStorage-test/MGT"
+
+    def __init__(self):
+        super().__init__()
+        self.setup_error_codes()
+        self._metadata_file_content = b'\x00' * 4 * 1024 * 1024
+
+    def start(self):
+        super().start()
+        self.patch("util.gen_uuid", new=genuuid)
+
+    def generate_device_paths(self):
+        for path in super().generate_device_paths():
+            yield path
+        yield self.METADATA_PATH
+
+    def fake_open(self, fname, mode='r'):
+        if fname != self.METADATA_PATH:
+            return super().fake_open(fname, mode)
+        else:
+            return LVMMetadataFile.open(self, mode)
+
+
+class LVMMetadataFile:
+    def __init__(self, context, can_read, can_write):
+        self._context = context
+        self._can_read = can_read
+        self._can_write = can_write
+        self._file = io.BytesIO(context._metadata_file_content)
+
+    @classmethod
+    def open(cls, context, mode):
+        # For now don't try to get clever about deciphering mode
+        # flags, just cope with the modes we know srmetadata uses.
+        assert mode in ("wb+", "rb")
+        if mode == "wb+":
+            return cls(context, True, True)
+        else:
+            return cls(context, True, False)
+
+    def read(self, size):
+        assert self._can_read
+        return self._file.read(size)
+
+    def write(self, data):
+        assert self._can_write
+        return self._file.write(data)
+
+    def seek(self, offset, whence=io.SEEK_SET):
+        self._file.seek(offset, whence)
+
+    def close(self):
+        content = self._file.getvalue()
+        self._file.close()
+        assert len(content) == len(self._context._metadata_file_content)
+        self._context._metadata_file_content = content
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self,exc_type, exc_value, traceback):
+        self.close()

--- a/tests/test_srmetadata.py
+++ b/tests/test_srmetadata.py
@@ -6,9 +6,9 @@ import uuid
 import unittest
 import unittest.mock as mock
 
-from srmetadata import (LVMMetadataHandler, buildHeader, getMetadataLength,
-                        getSectorAlignedXML, unpackHeader,
-                        updateLengthInHeader, MAX_VDI_NAME_LABEL_DESC_LENGTH)
+from srmetadata import (LVMMetadataHandler, buildHeader, buildXMLSector,
+                        getMetadataLength, unpackHeader, updateLengthInHeader,
+                        MAX_VDI_NAME_LABEL_DESC_LENGTH)
 
 
 class TestSRMetadataFunctions(unittest.TestCase):
@@ -40,19 +40,24 @@ class TestSRMetadataFunctions(unittest.TestCase):
         self.assertEqual(int(major), orig_major)
         self.assertEqual(int(minor), orig_minor)
 
-    def test_getSectorAlignedXML(self):
+    def test_buildXMLSector(self):
         # Given
         tag_name = "blah"
         value1 = "x" * (512 - len("<blah>") - len("</blah>"))
         value2 = value1 + "excess"
+        value3_deficit = 10
+        value3 = value1[:-value3_deficit]
 
         # When
-        xml1 = getSectorAlignedXML(tag_name, value1)
-        xml2 = getSectorAlignedXML(tag_name, value2)
+        xml1 = buildXMLSector(tag_name, value1)
+        xml2 = buildXMLSector(tag_name, value2)
+        xml3 = buildXMLSector(tag_name, value3)
 
         # Then
         self.assertEqual(xml1, "<blah>%s</blah>" % value1)
         self.assertEqual(xml2, xml1)
+        self.assertEqual(xml3,
+                         "<blah>%s</blah>" % value3 + " " * value3_deficit)
 
     def test_getMetadataLength(self):
         # Given

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -687,7 +687,8 @@ class TestUtil(unittest.TestCase):
         # Successive chars in this string have 1, 2, 3, and 4 byte encodings.
         # So the number of bytes required to encode some prefix of it will be
         # a triangle number.
-        s = "X\u00f6\u732b\U0001f3f9"
+        t = "X\u00f6\u732b\U0001f3f9"
+        s = "X\u00f6\u732b\U0001f3f9".encode("utf-8")
 
         self.assertEqual(util.unictrunc(s, 10), 10)
         self.assertEqual(util.unictrunc(s, 9), 6)
@@ -700,3 +701,15 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(util.unictrunc(s, 2), 1)
         self.assertEqual(util.unictrunc(s, 1), 1)
         self.assertEqual(util.unictrunc(s, 0), 0)
+
+        self.assertEqual(util.unictrunc(t, 10), 4)
+        self.assertEqual(util.unictrunc(t, 9), 3)
+        self.assertEqual(util.unictrunc(t, 8), 3)
+        self.assertEqual(util.unictrunc(t, 7), 3)
+        self.assertEqual(util.unictrunc(t, 6), 3)
+        self.assertEqual(util.unictrunc(t, 5), 2)
+        self.assertEqual(util.unictrunc(t, 4), 2)
+        self.assertEqual(util.unictrunc(t, 3), 2)
+        self.assertEqual(util.unictrunc(t, 2), 1)
+        self.assertEqual(util.unictrunc(t, 1), 1)
+        self.assertEqual(util.unictrunc(t, 0), 0)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -682,3 +682,21 @@ class TestUtil(unittest.TestCase):
         # Assert
         self.assertTrue(retval)
         self.assertSetEqual({'/var/run/blktap-control/nbd17405.0'}, sockets)
+
+    def test_unictrunc(self):
+        # Successive chars in this string have 1, 2, 3, and 4 byte encodings.
+        # So the number of bytes required to encode some prefix of it will be
+        # a triangle number.
+        s = "X\u00f6\u732b\U0001f3f9"
+
+        self.assertEqual(util.unictrunc(s, 10), 10)
+        self.assertEqual(util.unictrunc(s, 9), 6)
+        self.assertEqual(util.unictrunc(s, 8), 6)
+        self.assertEqual(util.unictrunc(s, 7), 6)
+        self.assertEqual(util.unictrunc(s, 6), 6)
+        self.assertEqual(util.unictrunc(s, 5), 3)
+        self.assertEqual(util.unictrunc(s, 4), 3)
+        self.assertEqual(util.unictrunc(s, 3), 3)
+        self.assertEqual(util.unictrunc(s, 2), 1)
+        self.assertEqual(util.unictrunc(s, 1), 1)
+        self.assertEqual(util.unictrunc(s, 0), 0)

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -121,21 +121,22 @@ class TestContext(object):
             ]
         )
 
+    def patch(self, *args, **kwargs):
+        patcher = mock.patch(*args, **kwargs)
+        self.patchers.append(patcher)
+        patcher.start()
+
     def start(self):
-        self.patchers = [
-            mock.patch('builtins.open', new=self.fake_open),
-            mock.patch('fcntl.fcntl', new=self.fake_fcntl),
-            mock.patch('os.path.exists', new=self.fake_exists),
-            mock.patch('os.makedirs', new=self.fake_makedirs),
-            mock.patch('os.listdir', new=self.fake_listdir),
-            mock.patch('glob.glob', new=self.fake_glob),
-            mock.patch('os.uname', new=self.fake_uname),
-            mock.patch('subprocess.Popen', new=self.fake_popen),
-            mock.patch('os.rmdir', new=self.fake_rmdir),
-            mock.patch('os.stat', new=self.fake_stat)
-        ]
-        for patcher in self.patchers:
-            patcher.start()
+        self.patch('builtins.open', new=self.fake_open)
+        self.patch('fcntl.fcntl', new=self.fake_fcntl)
+        self.patch('os.path.exists', new=self.fake_exists)
+        self.patch('os.makedirs', new=self.fake_makedirs)
+        self.patch('os.listdir', new=self.fake_listdir)
+        self.patch('glob.glob', new=self.fake_glob)
+        self.patch('os.uname', new=self.fake_uname)
+        self.patch('subprocess.Popen', new=self.fake_popen)
+        self.patch('os.rmdir', new=self.fake_rmdir)
+        self.patch('os.stat', new=self.fake_stat)
 
         self.setup_modinfo()
 


### PR DESCRIPTION
CA-379287 is a problem parsing XMLRPC requests that contained non-ascii characters, due to the way the body of a request would be passed on the command line, and then decoded to appear in `sys.argv`,

CP-383791 is an issue that is easier to provoke with CA-379287 fixed (which is why I'm putting them in the same PR): if there is a VDI in an LVM SR that has non-ascii characters in its name label, `LVMMetadataHandler` can no longer read the corresponding MGT file, at the code's implicit assumption that byte offsets and character offsets are the same thing. Before fixing that, I wanted to get better unit test coverage for the code in question, and clear out some cruft that was making the code harder to follow.