### PR TITLE
CP-45514: set ownership and permissions on backend

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -17,9 +17,10 @@
 #
 # blktap2: blktap/tapdisk management layer
 #
-
+import grp
 import os
 import re
+import stat
 import time
 import copy
 from lock import Lock
@@ -1250,7 +1251,9 @@ class VDI(object):
             if not S_ISBLK(st.st_mode):
                 raise self.NotABlockDevice(target, st)
 
-            os.mknod(self.path(), st.st_mode, st.st_rdev)
+            # set group read for disk group as well as root
+            os.mknod(self.path(), st.st_mode | stat.S_IRGRP, st.st_rdev)
+            os.chown(self.path(), st.st_uid, grp.getgrnam("disk").gr_gid)
 
         def _equals(self, target):
             target_rdev = self._real_stat(target).st_rdev


### PR DESCRIPTION
To allow for depriviling pygrub the /dev/sm/backend/ devices need to have group ownership for the disk group and for the group to be granted read-only access to the device.