### PR TITLE
fix(NFSSR): ensure we can attach SR during attach_from_config call

### DIFF
--- a/tests/test_FileSR.py
+++ b/tests/test_FileSR.py
@@ -13,7 +13,6 @@ import SR
 import SRCommand
 import util
 import vhdutil
-from XenAPI import Failure
 
 
 class FakeFileVDI(FileSR.FileVDI):
@@ -191,6 +190,7 @@ class TestFileVDI(unittest.TestCase):
         vdi_uuid = str(uuid.uuid4())
         sr = mock.MagicMock()
         sr.path = "sr_path"
+        sr._check_hardlinks.return_value = False
         vdi = FakeFileVDI(sr, vdi_uuid)
         vdi.sr = sr
 
@@ -202,9 +202,6 @@ class TestFileVDI(unittest.TestCase):
         grandp_uuid = str(uuid.uuid4())
 
         mock_query_p_uuid.side_effect = [new_vdi_uuid, new_vdi_uuid, grandp_uuid]
-
-        sr.session.xenapi.SR.get_sm_config.return_value = {
-            "no_hardlinks": "True"}
 
         # Act
         clone_xml = vdi.clone(sr_uuid, vdi_uuid)
@@ -429,6 +426,8 @@ class FakeSharedFileSR(FileSR.SharedFileSR):
     def attach(self, sr_uuid):
         self._check_hardlinks()
 
+    def _read_hardlink_conf(self):
+        return None
 
 class TestShareFileSR(unittest.TestCase):
     """
@@ -436,7 +435,6 @@ class TestShareFileSR(unittest.TestCase):
     """
     TEST_SR_REF = "test_sr_ref"
     ERROR_524 = "Unknown error 524"
-    NO_HARDLINKS = "no_hardlinks"
 
     def setUp(self):
         util_patcher = mock.patch('FileSR.util', autospec=True)
@@ -485,8 +483,7 @@ class TestShareFileSR(unittest.TestCase):
             test_sr.attach(self.sr_uuid)
 
         # Assert
-        self.mock_session.xenapi.SR.remove_from_sm_config.assert_called_with(
-            TestShareFileSR.TEST_SR_REF, TestShareFileSR.NO_HARDLINKS)
+        self.assertEqual(0, self.mock_session.xenapi.message.create.call_count)
 
     def test_attach_link_fail(self):
         """
@@ -501,30 +498,8 @@ class TestShareFileSR(unittest.TestCase):
             test_sr.attach(self.sr_uuid)
 
         # Assert
-        self.mock_session.xenapi.SR.add_to_sm_config.assert_called_with(
-            TestShareFileSR.TEST_SR_REF, TestShareFileSR.NO_HARDLINKS, 'True')
         self.mock_session.xenapi.message.create.assert_called_with(
             'sr_does_not_support_hardlinks', 2, "SR", self.sr_uuid, mock.ANY)
-
-    def test_attach_link_fail_already_set(self):
-        """
-        Attach SR on FS with no hardlinks with config set
-        """
-        test_sr = self.create_test_sr()
-
-        self.mock_link.side_effect = OSError(524, TestShareFileSR.ERROR_524)
-        self.mock_session.xenapi.SR.add_to_sm_config.side_effect = Failure(
-            ['MAP_DUPLICATE_KEY', 'SR', 'sm_config',
-            'OpaqueRef:be8cc595-4924-4946-9082-59aef531daae',
-             TestShareFileSR.NO_HARDLINKS])
-
-        # Act
-        with mock.patch('FileSR.open'):
-            test_sr.attach(self.sr_uuid)
-
-        # Assert
-        self.mock_session.xenapi.SR.add_to_sm_config.assert_called_with(
-            TestShareFileSR.TEST_SR_REF, TestShareFileSR.NO_HARDLINKS, 'True')
 
     def test_attach_fist_active(self):
         """
@@ -539,8 +514,6 @@ class TestShareFileSR(unittest.TestCase):
             test_sr.attach(self.sr_uuid)
 
         # Assert
-        self.mock_session.xenapi.SR.add_to_sm_config.assert_called_with(
-            TestShareFileSR.TEST_SR_REF, TestShareFileSR.NO_HARDLINKS, 'True')
         self.mock_session.xenapi.message.create.assert_called_with(
             'sr_does_not_support_hardlinks', 2, "SR", self.sr_uuid, mock.ANY)
 


### PR DESCRIPTION
We can get a trace like that if the SR is not attached:
```
2170:Oct 10 16:02:59 xcp4 SM: [2564] ***** NFSFileVDI.attach_from_config: EXCEPTION <type 'exceptions.AttributeError'>, 'NoneType' object has no attribute 'xenapi'
2329-Oct 10 16:02:59 xcp4 SM: [2564]   File "/opt/xensource/sm/NFSSR", line 296, in attach_from_config
2427-Oct 10 16:02:59 xcp4 SM: [2564]     self.sr.attach(sr_uuid)
2487-Oct 10 16:02:59 xcp4 SM: [2564]   File "/opt/xensource/sm/NFSSR", line 148, in attach
2573-Oct 10 16:02:59 xcp4 SM: [2564]     self._check_hardlinks()
2633-Oct 10 16:02:59 xcp4 SM: [2564]   File "/opt/xensource/sm/FileSR.py", line 1122, in _check_hardlinks
2734-Oct 10 16:02:59 xcp4 SM: [2564]     self.session.xenapi.SR.remove_from_sm_config(
2816-Oct 10 16:02:59 xcp4 SM: [2564]
```

Because the session is not set during this call.
So instead of using the XenAPI to store hardlink support, use a file on the storage itself.