### PR TITLE
CA-384030 Ignore awkardly named images in ISO SRs

### DIFF
--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -130,6 +130,7 @@ class TestContext(object):
         self.patch('builtins.open', new=self.fake_open)
         self.patch('fcntl.fcntl', new=self.fake_fcntl)
         self.patch('os.path.exists', new=self.fake_exists)
+        self.patch('os.path.isdir', new=self.fake_isdir),
         self.patch('os.makedirs', new=self.fake_makedirs)
         self.patch('os.listdir', new=self.fake_listdir)
         self.patch('glob.glob', new=self.fake_glob)
@@ -236,6 +237,9 @@ class TestContext(object):
 
         self.log('not exists', fname)
         return False
+
+    def fake_isdir(self, fname):
+        return fname in self.get_created_directories()
 
     def fake_listdir(self, path):
         assert '*' not in path


### PR DESCRIPTION
 * Use os.listdir rather than util.listdir for finding images in an SMB share. I don't really know why the latter exists, but I didn't want to get side-tracked by the question of whether it could be eliminated or (if not) how it should best handle non-ascii characters in filenames - especially as I doubt that's ever an issue outside of ISOSR.py.
* Refactor the identification of images so that finding and filtering are in a single function.
* When looking for image files in a mounted directory, ignore ones with problematic names. This covers non-utf-8 names (which will always be a problem, but that aren't likely to occur in this context), and names that have had their utf-8 encodings mangled by Python's filesystem encodings (which I'm anticipating will stop being a problem with Python 3.7 and later).
* When an ISO SR is being created, look to see if there are image files with problematic names, but if there are create an alert message rather than refuse to create the SR.
    
Signed-off-by: Robin Newton <robin.newton@cloud.com>