### PR TITLE
CP-45927: set multipath checker for Equalogic 100E-00 to tur

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -76,7 +76,7 @@ devices {
         vendor                      "EQLOGIC"
         product                     "100E-00"
         path_grouping_policy        multibus
-        path_checker                readsector0
+        path_checker                tur
         failback                    immediate
         path_selector               "round-robin 0"
         rr_min_io                   3


### PR DESCRIPTION
From Dell's doc - https://i.dell.com/sites/csdocuments/Shared-Content_data-Sheets_Documents/ar/dz/ESG-TechWP-EQL-MultipathIOwithCitrixXenServer.pdf

```
Note: There is a known issue with Linux multipathing daemon (multipathd) versions built from source 
prior to May 2011 when using path_checker readsector0 in the devices section of the 
multipath.conf file. Using this value will cause iSCSI protocol errors when used with Dell EqualLogic PS 
Series Firmware v7.x. This issue does not exist with versions of Dell EqualLogic PS Series Firmware prior 
to Version 7.0. Upgrading to Dell EqualLogic PS Series Firmware Version 7.x with path_checker 
readsector0 set will result in total connectivity loss.
```