### PR TITLE
fix(ISOSR): type accepts 'nfs_iso' not 'nfs' as the docs claim

### DIFF
--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -30,12 +30,17 @@ import cifutils
 CAPABILITIES = ["VDI_CREATE", "VDI_DELETE", "VDI_ATTACH", "VDI_DETACH",
                 "SR_SCAN", "SR_ATTACH", "SR_DETACH"]
 
-CONFIGURATION = \
-    [['location', 'path to mount (required) (e.g. server:/path)'],
-      ['options',
-        'extra options to pass to mount (deprecated) (e.g. \'-o ro\')'],
-      ['type', 'cifs or nfs_iso'],
-      nfs.NFS_VERSION]
+CONFIGURATION = [
+    ['location', 'path to mount (required) (e.g. server:/path)'],
+    ['options',
+     'extra options to pass to mount (e.g. \'-o ro\')'],
+    ['type', 'cifs (SMB) or nfs_iso'],
+    nfs.NFS_VERSION,
+    ['vers', 'SMB version, default version 3'],
+    ['username', r'Username to authenticate to SMB share with, can be domain\username'],
+    ['cifspassword_secret', 'Secret ID containing the password to authenticate to SMB'],
+    ['cifspassword', 'Password to authenticate to SMB, (deprecated see cifspassword_secret)']
+]
 
 DRIVER_INFO = {
     'name': 'ISO',

--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -34,7 +34,7 @@ CONFIGURATION = \
     [['location', 'path to mount (required) (e.g. server:/path)'],
       ['options',
         'extra options to pass to mount (deprecated) (e.g. \'-o ro\')'],
-      ['type', 'cifs or nfs'],
+      ['type', 'cifs or nfs_iso'],
       nfs.NFS_VERSION]
 
 DRIVER_INFO = {

--- a/drivers/nfs.py
+++ b/drivers/nfs.py
@@ -46,7 +46,7 @@ NFS_STAT = "/usr/sbin/nfsstat"
 DEFAULT_NFSVERSION = '3'
 
 NFS_VERSION = [
-    'nfsversion', 'for type=nfs, NFS protocol version - 3, 4, 4.0, 4.1']
+    'nfsversion', 'NFS protocol version - 3, 4, 4.0, 4.1']
 
 NFS_SERVICE_WAIT = 30
 NFS_SERVICE_RETRY = 6


### PR DESCRIPTION
See https://github.com/xapi-project/sm/blob/master/drivers/ISOSR.py#L318-L326 

Valid values for type are `cifs` or `nfs_iso`. That is not very consistent but the built-in docs should reflect reality, the code can be extended later to support more consistent naming.