### PR TITLE
CP-46863 Dump Multipath Status from Storage Manager

### DIFF
--- a/systemd/mpathcount.service
+++ b/systemd/mpathcount.service
@@ -7,5 +7,6 @@ After=xapi-init-complete.target
 StandardInput=socket
 StandardOutput=null
 StandardError=journal
+ExecStartPre=/bin/bash -c 'if [ ! -f "/dev/shm/mpath_status" ]; then /opt/xensource/sm/mpathcount.py; fi'
 ExecStart=/usr/bin/sh -c '. /etc/xensource-inventory; while dd of=/dev/null bs=4096 count=1 status=none conv=noerror; do /opt/xensource/sm/mpathcount.py; done'
 Restart=always

--- a/tests/test_mpathcount.py
+++ b/tests/test_mpathcount.py
@@ -112,7 +112,7 @@ class TestMpathCount(unittest.TestCase):
                 print("del {}".format(key))
                 del store[key]
 
-        def fake_update_config(k, s, v, a, t):
+        def fake_update_config(k, s, v, a, t, p):
             store[k] = v
 
         update_config.side_effect = fake_update_config


### PR DESCRIPTION
- Save the multi-path status to a regular file whenever a Udev event is triggered.
- Generate the 'mp_status' file if it does not exist when starting the 'mpathcount' service for the first time.