### PR TITLE
CA-386281 CIFS username can be omitted in ISO SR

### DIFF
--- a/drivers/ISOSR.py
+++ b/drivers/ISOSR.py
@@ -546,12 +546,11 @@ class ISOSR(SR.SR):
 
             if not cifutils.containsCredentials(self.dconf, prefix="cifs"):
                 options.append('guest')
+                domain = None
+            else:
+                _, domain = cifutils.splitDomainAndUsername(self.dconf['username'])
 
             options.append(self.getSMBVersion())
-
-            username, domain = (
-                cifutils.splitDomainAndUsername(self.dconf['username'])
-            )
 
             if domain:
                 options.append('domain=' + domain)

--- a/tests/test_ISOSR.py
+++ b/tests/test_ISOSR.py
@@ -194,16 +194,14 @@ class TestISOSR_overSMB(unittest.TestCase):
 
     def create_smbisosr(self, location='\\aServer\aLocation', atype=None,
                         sr_uuid='asr_uuid', server='\\aServer',
-                        serverpath='/aServerpath', username='aUsername',
-                        password='aPassword', vers=None, options='',
+                        serverpath='/aServerpath',
+                        vers=None, options='',
                         dconf_update={}):
         srcmd = mock.Mock()
         srcmd.dconf = {
             'location': location,
             'server': server,
             'serverpath': serverpath,
-            'username': username,
-            'password': password,
             'options': options
         }
         if vers:
@@ -252,7 +250,7 @@ class TestISOSR_overSMB(unittest.TestCase):
         Positive case, over XC/XE CLI with version 1.0.
         """
         context.setup_error_codes()
-        update = {'cifspassword': 'winter2019'}
+        update = {'username': 'dot', 'cifspassword': 'winter2019'}
         smbsr = self.create_smbisosr(atype='cifs', vers='1.0',
                                      dconf_update=update)
         _checkmount.side_effect = [False, True]
@@ -260,7 +258,7 @@ class TestISOSR_overSMB(unittest.TestCase):
         pread.assert_called_with(['mount.cifs', '\\aServer\x07Location',
                                   '/var/run/sr-mount/asr_uuid', '-o',
                                  'cache=none,vers=1.0'], True,
-                                 new_env={'PASSWD': 'winter2019', 'USER': 'aUsername'})
+                                 new_env={'PASSWD': 'winter2019', 'USER': 'dot'})
 
     @testlib.with_context
     @mock.patch('util.makedirs')
@@ -274,9 +272,8 @@ class TestISOSR_overSMB(unittest.TestCase):
         Positive case, over XC/XE CLI with version 1.0.
         """
         context.setup_error_codes()
-        update = {'cifspassword': 'winter2019'}
+        update = {'username': r'citrix\jsmith', 'cifspassword': 'winter2019'}
         smbsr = self.create_smbisosr(atype='cifs', vers='1.0',
-                                     username=r'citrix\jsmith',
                                      dconf_update=update)
         _checkmount.side_effect = [False, True]
         smbsr.attach(None)


### PR DESCRIPTION
ISOSR falling over when no username is given is a regression that looks to have been introduced in commit
cbd7226b012d145b52ef50c45c69987d4050b12a when the use of a credentials file was removed.

The ISOSR unit tests were already covered cases of not having credentials - as evinced by having "guest" in the expected mount options. However, they were doing this in a rather confused way that hid the bug by supplying a username regardless. Now only the credentials tests do this.