### PR TITLE
Implement correctly fake_import in test_on_slave.py

### DIFF
--- a/tests/test_on_slave.py
+++ b/tests/test_on_slave.py
@@ -15,9 +15,9 @@ class Test_on_slave_is_open(unittest.TestCase):
 
     MOCK_IMPORTS = ['SRCommand', 'SR', 'NFSSR', 'EXTSR', 'LVHDSR', 'blktap2']
 
-    def fake_import(self, name, *args):
-        print('Asked to import {}'.format(name))
-        return self.mocks.get(name, self.real_import(name))
+    def fake_import(self, *args, **kwargs):
+        print('Asked to import {}'.format(args[0]))
+        return self.mocks.get(args[0], self.real_import(*args, **kwargs))
 
     def setUp(self):
         self.addCleanup(mock.patch.stopall)


### PR DESCRIPTION
*args and **kwargs must be forwarded to __import__ otherwise the import context (global & local) can be incomplete to find local paths of external modules. In this situation, "ValueError: Empty module name" is thrown.