### PR TITLE
CP-39600: remove stray print call

### DIFF
--- a/drivers/lock_queue.py
+++ b/drivers/lock_queue.py
@@ -88,7 +88,7 @@ class LockQueue:
             self._queue_lock.acquire()
             queue = self.load_queue()
             front_pid, front_start_time = queue.pop(0)
-            print(f"Testing for PID {front_pid}")
+            debug_log(f"Testing for PID {front_pid}")
             if front_pid == os.getpid():
                 # We are at the front, it is now our turn to wait on the action lock
                 # and then do our work


### PR DESCRIPTION
This was breaking storage-init as it goes back into the XML stream to the toolstack and causes an XML parse failure.