### PR TITLE
CA-390490: remove override of blktap request timeout

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -995,13 +995,6 @@ class VDI(object):
 
     ATTACH_DETACH_RETRY_SECS = 120
 
-    # number of seconds on top of NFS timeo mount option the tapdisk should
-    # wait before reporting errors. This is to allow a retry to succeed in case
-    # packets were lost the first time around, which prevented the NFS client
-    # from returning before the timeo is reached even if the NFS server did
-    # come back earlier
-    TAPDISK_TIMEOUT_MARGIN = 30
-
     def __init__(self, uuid, target, driver_info):
         self.target = self.TargetDriver(target, driver_info)
         self._vdi_uuid = uuid
@@ -1583,11 +1576,6 @@ class VDI(object):
 
         sr_ref = self.target.vdi.sr.srcmd.params.get('sr_ref')
         sr_other_config = self._session.xenapi.SR.get_other_config(sr_ref)
-        timeout = nfs.get_nfs_timeout(sr_other_config)
-        if timeout:
-            # Note NFS timeout values are in deciseconds
-            timeout = int((timeout + 5) / 10)
-            options["timeout"] = timeout + self.TAPDISK_TIMEOUT_MARGIN
         for i in range(self.ATTACH_DETACH_RETRY_SECS):
             try:
                 if self._activate_locked(sr_uuid, vdi_uuid, options):


### PR DESCRIPTION
When this code was orginally added there was no default value for the nfs_timeout and so the timeout would only have been used if
1. The SR type was NFS
2. The SR had a overriden setting for nfs-timeout in the other-config

Since that time the calculation of the NFS client timeout has been changed considerably and is set with a balance between timeo and retrans values. In particular the get_nfs_timeout method will now always return a non-zero value.  This results in the SM always applying a request timeout to blktap of 50 seconds (unless the timeo value has been set in the SR device config), which is considerably lower than the default request timeout in blktap itself which is 120 seconds.

NFS protocol timeouts are also no longer considered to be retryable errors within blktap so tying the timeout value to the NFS timeout, even if it were correctly calculated taking into account the retrans value, is effectively comparing two unrelated things.