### PR TITLE
Make use of new fair locking subsystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ precommit: build
 	CHANGED=$$(git status --porcelain $(SM_PY_FILES) | awk '{print $$2}'); \
 	for i in $$CHANGED; do \
 		echo Checking $${i} ...; \
-		PYTHONPATH=./drivers:$$PYTHONPATH $(PYLINT) --rcfile=tests/pylintrc $${i}; \
+		PYTHONPATH=./drivers:./misc/fairlock:$$PYTHONPATH $(PYLINT) --rcfile=tests/pylintrc $${i}; \
 		[ $$? -ne 0 ] && QUIT=1 ; \
 	done; \
 	if [ $$QUIT -ne 0 ]; then \
@@ -111,7 +111,7 @@ precommit: build
 
 .PHONY: precheck
 precheck: build
-	PYTHONPATH=./drivers:$$PYTHONPATH $(PYLINT) --rcfile=tests/pylintrc $(SM_PY_FILES)
+	PYTHONPATH=./drivers:./misc/fairlock:$$PYTHONPATH $(PYLINT) --rcfile=tests/pylintrc $(SM_PY_FILES)
 	echo "Precheck succeeded with no outstanding issues found."
 
 .PHONY: install

--- a/drivers/mpath_cli.py
+++ b/drivers/mpath_cli.py
@@ -18,6 +18,7 @@
 import util
 import re
 import time
+from fairlock import Fairlock
 
 
 class MPathCLIFail(Exception):
@@ -32,7 +33,8 @@ mpathcmd = ["/usr/sbin/multipathd", "-k"]
 
 def mpexec(cmd):
     util.SMlog("mpath cmd: %s" % cmd)
-    (rc, stdout, stderr) = util.doexec(mpathcmd, cmd)
+    with Fairlock("multipath"):
+        (rc, stdout, stderr) = util.doexec(mpathcmd, cmd)
     if stdout != "multipathd> ok\nmultipathd> " \
             and stdout != "multipathd> " + cmd + "\nok\nmultipathd> ":
         raise MPathCLIFail
@@ -77,7 +79,8 @@ def is_working():
 
 def do_get_topology(cmd):
     util.SMlog("mpath cmd: %s" % cmd)
-    (rc, stdout, stderr) = util.doexec(mpathcmd, cmd)
+    with Fairlock("multipath"):
+        (rc, stdout, stderr) = util.doexec(mpathcmd, cmd)
     util.SMlog("mpath output: %s" % stdout)
     lines = stdout.split('\n')[:-1]
     if len(lines):
@@ -109,7 +112,8 @@ def list_paths(scsi_id):
 def list_maps():
     cmd = "list maps"
     util.SMlog("mpath cmd: %s" % cmd)
-    (rc, stdout, stderr) = util.doexec(mpathcmd, cmd)
+    with Fairlock("multipath"):
+        (rc, stdout, stderr) = util.doexec(mpathcmd, cmd)
     util.SMlog("mpath output: %s" % stdout)
     return [x.split(' ')[0] for x in stdout.split('\n')[2:-1]]
 

--- a/drivers/mpath_cli.py
+++ b/drivers/mpath_cli.py
@@ -33,7 +33,7 @@ mpathcmd = ["/usr/sbin/multipathd", "-k"]
 
 def mpexec(cmd):
     util.SMlog("mpath cmd: %s" % cmd)
-    with Fairlock("multipath"):
+    with Fairlock("devicemapper"):
         (rc, stdout, stderr) = util.doexec(mpathcmd, cmd)
     if stdout != "multipathd> ok\nmultipathd> " \
             and stdout != "multipathd> " + cmd + "\nok\nmultipathd> ":
@@ -79,7 +79,7 @@ def is_working():
 
 def do_get_topology(cmd):
     util.SMlog("mpath cmd: %s" % cmd)
-    with Fairlock("multipath"):
+    with Fairlock("devicemapper"):
         (rc, stdout, stderr) = util.doexec(mpathcmd, cmd)
     util.SMlog("mpath output: %s" % stdout)
     lines = stdout.split('\n')[:-1]
@@ -112,7 +112,7 @@ def list_paths(scsi_id):
 def list_maps():
     cmd = "list maps"
     util.SMlog("mpath cmd: %s" % cmd)
-    with Fairlock("multipath"):
+    with Fairlock("devicemapper"):
         (rc, stdout, stderr) = util.doexec(mpathcmd, cmd)
     util.SMlog("mpath output: %s" % stdout)
     return [x.split(' ')[0] for x in stdout.split('\n')[2:-1]]

--- a/drivers/mpath_dmp.py
+++ b/drivers/mpath_dmp.py
@@ -78,7 +78,7 @@ def _resetDMP(sid, explicit_unmap=False):
 # tables. In that case, list_paths will return [], but remove_map might
 # throw an exception. Catch it and ignore it.
     if explicit_unmap:
-        with Fairlock("multipath"):
+        with Fairlock("devicemapper"):
             util.retry(lambda: util.pread2(['/usr/sbin/multipath', '-f', sid]),
                     maxretry=3, period=4)
             util.retry(lambda: util.pread2(['/usr/sbin/multipath', '-W']), maxretry=3,
@@ -111,13 +111,13 @@ def refresh(sid, npaths):
 def _is_valid_multipath_device(sid):
 
     # Check if device is already multipathed
-    with Fairlock("multipath"):
+    with Fairlock("devicemapper"):
         (ret, stdout, stderr) = util.doexec(['/usr/sbin/multipath', '-l', sid])
     if not stdout + stderr:
-        with Fairlock("multipath"):
+        with Fairlock("devicemapper"):
             (ret, stdout, stderr) = util.doexec(['/usr/sbin/multipath', '-ll', sid])
     if not stdout + stderr:
-        with Fairlock("multipath"):
+        with Fairlock("devicemapper"):
             (ret, stdout, stderr) = util.doexec(['/usr/sbin/multipath', '-a', sid])
         if ret < 0:
             util.SMlog("Failed to add {}: wwid could be explicitly "
@@ -136,7 +136,7 @@ def _is_valid_multipath_device(sid):
         for dev in devs:
             devpath = os.path.join(by_scsid_path, dev)
             real_path = util.get_real_path(devpath)
-            with Fairlock("multipath"):
+            with Fairlock("devicemapper"):
                 (ret, stdout, stderr) = util.doexec(['/usr/sbin/multipath', '-c', real_path])
                 if ret == 0:
                     break
@@ -150,7 +150,7 @@ def _is_valid_multipath_device(sid):
             if not stdout + stderr:
                 # Attempt to cleanup wwids file before raising
                 try:
-                    with Fairlock("multipath"):
+                    with Fairlock("devicemapper"):
                         (ret, stdout, stderr) = util.doexec(['/usr/sbin/multipath', '-w', sid])
                 except OSError:
                     util.SMlog("Error removing {} from wwids file".format(sid))
@@ -170,7 +170,7 @@ def _refresh_DMP(sid, npaths):
     path = os.path.join(DEVMAPPERPATH, sid)
     # If the mapper path doesn't exist force a reload in multipath
     if not os.path.exists(path):
-        with Fairlock("multipath"):
+        with Fairlock("devicemapper"):
             util.retry(lambda: util.pread2(['/usr/sbin/multipath', '-r', sid]), maxretry=3, period=4)
         util.wait_for_path(path, 30)
     if not os.path.exists(path):

--- a/tests/test_LVHDSR.py
+++ b/tests/test_LVHDSR.py
@@ -54,7 +54,7 @@ class TestLVHDSR(unittest.TestCase, Stubs):
             sr_uuid = str(uuid.uuid4())
         return LVHDSR.LVHDSR(srcmd, sr_uuid)
 
-    @mock.patch('lvutil.LvmLockContext', autospec=True)
+    @mock.patch('lvutil.Fairlock', autospec=True)
     @mock.patch('lvhdutil.getVDIInfo', autospec=True)
     @mock.patch('LVHDSR.Lock', autospec=True)
     @mock.patch('SR.XenAPI')

--- a/tests/test_LVHDoHBASR.py
+++ b/tests/test_LVHDoHBASR.py
@@ -87,7 +87,7 @@ class TestLVHDoHBASR(unittest.TestCase):
         self.mock_lvhdsr = lvhdsr_patcher.start()
         util_patcher = mock.patch('LVHDoHBASR.util', autospec=True)
         self.mock_util = util_patcher.start()
-        lc_patcher = mock.patch('LVHDSR.lvmcache.lvutil.LvmLockContext', autospec=True)
+        lc_patcher = mock.patch('LVHDSR.lvmcache.lvutil.Fairlock', autospec=True)
         self.mock_lc = lc_patcher.start()
         xenapi_patcher = mock.patch('SR.XenAPI')
         self.mock_xapi = xenapi_patcher.start()

--- a/tests/test_LVHDoISCSISR.py
+++ b/tests/test_LVHDoISCSISR.py
@@ -162,7 +162,7 @@ class TestLVHDoISCSISR(ISCSITestCase):
 
         lock_patcher = mock.patch('LVHDSR.Lock')
         self.mock_lock = lock_patcher.start()
-        lvlock_patcher = mock.patch('LVHDSR.lvutil.LvmLockContext')
+        lvlock_patcher = mock.patch('LVHDSR.lvutil.Fairlock')
         self.mock_lvlock = lvlock_patcher.start()
 
         self.addCleanup(mock.patch.stopall)

--- a/tests/test_mpath_dmp.py
+++ b/tests/test_mpath_dmp.py
@@ -30,6 +30,9 @@ class TestMpathDmp(unittest.TestCase):
         mpath_cli_patcher = mock.patch('mpath_dmp.mpath_cli', autospec=True)
         self.mock_mpath_cli = mpath_cli_patcher.start()
 
+        lock_patcher = mock.patch('mpath_dmp.Fairlock', autospec=True)
+        self.mock_lock = lock_patcher.start()
+
         self.addCleanup(mock.patch.stopall)
 
     @testlib.with_context


### PR DESCRIPTION
Wrap calls to commands which need to access the device mapper in a context manager for a resource called "device-mapper" so that they get serialised in a fair manner (no queue-jumping like a lockfile would have).
