### PR TITLE
CA-392823: ensure no device mapper conflicts in LVHDSR detach

### DIFF
--- a/drivers/util.py
+++ b/drivers/util.py
@@ -1496,7 +1496,7 @@ def findRunningProcessOrOpenFile(name, process=True):
         # There is no specific guarantee of when a PID's /proc directory will disappear
         # when it exits, particularly relative to filedescriptor cleanup, so we want to
         # make sure we're not reporting a false positive.
-        processandpids = [ x for x in processandpids if pid_is_alive(x[1]) ]
+        processandpids = [x for x in processandpids if pid_is_alive(int(x[1]))]
         for pp in processandpids:
             SMlog(f"File {name} has an open handle with process {pp[0]} with pid {pp[1]}")
 


### PR DESCRIPTION
Within the detach operation checks are made that none of the device mapper devices for the SR volume group have opern handles. The falls false if operations on other LVM srs happen to call a device mapper operation such as `lvs` or `vgs` at the point the check is made as these operations can result in all of the devices managed by the device mapper subsystem being accessed as part of the scan. this then gives a false response for the open file handles check.