### PR TITLE
CP-49689: remove reverse dependency on SR from xs_errors 

### DIFF
--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -1430,7 +1430,7 @@ class LVHDVDI(VDI.VDI):
         util.SMlog("LVHDVDI.delete for %s" % self.uuid)
         try:
             self._loadThis()
-        except SR.SRException as e:
+        except xs_errors.SRException as e:
             # Catch 'VDI doesn't exist' exception
             if e.errno == 46:
                 return super(LVHDVDI, self).delete(sr_uuid, vdi_uuid, data_only)
@@ -1462,7 +1462,7 @@ class LVHDVDI(VDI.VDI):
             self.sr.lvmCache.remove(self.lvname)
             self.sr.lock.cleanup(vdi_uuid, lvhdutil.NS_PREFIX_LVM + sr_uuid)
             self.sr.lock.cleanupAll(vdi_uuid)
-        except SR.SRException as e:
+        except xs_errors.SRException as e:
             util.SMlog(
                 "Failed to remove the volume (maybe is leaf coalescing) "
                 "for %s err:%d" % (self.uuid, e.errno))

--- a/drivers/LVHDoISCSISR.py
+++ b/drivers/LVHDoISCSISR.py
@@ -177,7 +177,7 @@ class LVHDoISCSISR(LVHDSR.LVHDSR):
         try:
             self.iscsi = self.iscsiSRs[0]
         except IndexError as exc:
-            if isinstance(saved_exc, SR.SROSError):
+            if isinstance(saved_exc, xs_errors.SROSError):
                 raise saved_exc  # pylint: disable-msg=E0702
             elif isinstance(saved_exc, Exception):
                 raise xs_errors.XenError('SMGeneral', str(saved_exc))
@@ -453,7 +453,7 @@ class LVHDoISCSISR(LVHDSR.LVHDSR):
             for i in self.iscsiSRs:
                 try:
                     i.attach(sr_uuid)
-                except SR.SROSError as inst:
+                except xs_errors.SROSError as inst:
                     # Some iscsi objects can fail login/discovery but not all. Storing exception
                     if inst.errno in [141, 83]:
                         util.SMlog("Connection failed for target %s, continuing.." % i.target)
@@ -495,7 +495,7 @@ class LVHDoISCSISR(LVHDSR.LVHDSR):
             for i in self.iscsiSRs:
                 try:
                     i.attach(sr_uuid)
-                except SR.SROSError:
+                except xs_errors.SROSError:
                     util.SMlog("Connection failed for target %s, continuing.." % i.target)
         LVHDSR.LVHDSR.scan(self, sr_uuid)
 
@@ -532,7 +532,7 @@ class LVHDoISCSISR(LVHDSR.LVHDSR):
                     for iscsi in self.iscsiSRs:
                         try:
                             iscsi.attach(sr_uuid)
-                        except SR.SROSError:
+                        except xs_errors.SROSError:
                             util.SMlog("Failed to attach iSCSI target")
 
     def vdi(self, uuid):

--- a/drivers/SR.py
+++ b/drivers/SR.py
@@ -20,7 +20,6 @@
 
 import VDI
 import xml.dom.minidom
-import errno
 import xs_errors
 import XenAPI # pylint: disable=import-error
 import xmlrpc.client
@@ -38,23 +37,7 @@ MASTER_LVM_CONF = '/etc/lvm/master'
 LUNPERVDI = "LUNperVDI"
 
 
-class SRException(Exception):
-    """Exception raised by storage repository operations"""
-    errno = errno.EINVAL
 
-    def __init__(self, reason):
-        Exception.__init__(self, reason)
-
-    def toxml(self):
-        return xmlrpc.client.dumps(xmlrpc.client.Fault(int(self.errno), str(self)), "", True)
-
-
-class SROSError(SRException):
-    """Wrapper for OSError"""
-
-    def __init__(self, errno, reason):
-        self.errno = errno
-        Exception.__init__(self, reason)
 
 
 def deviceCheck(op):

--- a/drivers/SRCommand.py
+++ b/drivers/SRCommand.py
@@ -389,7 +389,7 @@ def run(driver, driver_info):
         else:
             print(ret)
 
-    except (Exception, SR.SRException) as e:
+    except (Exception, xs_errors.SRException) as e:
         try:
             util.logException(driver_info['name'])
         except KeyError:
@@ -400,7 +400,7 @@ def run(driver, driver_info):
         # If exception is of type SR.SRException, pass to Xapi.
         # If generic python Exception, print a generic xmlrpclib
         # dump and pass to XAPI.
-        if isinstance(e, SR.SRException):
+        if isinstance(e, xs_errors.SRException):
             print(e.toxml())
         else:
             print(xmlrpc.client.dumps(xmlrpc.client.Fault(1200, str(e)), "", True))

--- a/drivers/sr_health_check.py
+++ b/drivers/sr_health_check.py
@@ -22,7 +22,7 @@ SR implementation type dependent.
 
 import SR
 import util
-
+import xs_errors
 
 def main():
     """
@@ -30,7 +30,7 @@ def main():
     """
     try:
         session = util.get_localAPI_session()
-    except SR.SROSError:
+    except xs_errors.SROSError:
         util.SMlog("Unable to open local XAPI session", priority=util.LOG_ERR)
         return
 

--- a/drivers/xs_errors.py
+++ b/drivers/xs_errors.py
@@ -22,7 +22,8 @@ import xml.dom.minidom
 import util
 import xmlrpc.client
 
-XML_DEFS = '/opt/xensource/sm/XE_SR_ERRORCODES.xml'
+DEF_LOC = os.path.dirname(__file__)
+XML_DEFS = os.path.join(DEF_LOC, 'XE_SR_ERRORCODES.xml')
 
 
 class SRException(Exception):
@@ -33,7 +34,8 @@ class SRException(Exception):
         Exception.__init__(self, reason)
 
     def toxml(self):
-        return xmlrpc.client.dumps(xmlrpc.client.Fault(int(self.errno), str(self)), "", True)
+        return xmlrpc.client.dumps(xmlrpc.client.Fault(
+            int(self.errno), str(self)), "", True)
 
 
 class SROSError(SRException):
@@ -68,7 +70,8 @@ class XenError(Exception):
             errormessage = subdict['description']
             if opterr is not None:
                 errormessage += " [opterr=%s]" % opterr
-            util.SMlog("Raising exception [%d, %s]" % (errorcode, errormessage))
+            util.SMlog("Raising exception [%d, %s]" %
+                       (errorcode, errormessage))
             return SROSError(errorcode, errormessage)
 
         # development error

--- a/tests/test_BaseISCSI.py
+++ b/tests/test_BaseISCSI.py
@@ -3,16 +3,13 @@ Unit tests for the Base ISCSI SR
 """
 
 from unittest import mock
-import unittest
 from uuid import uuid4
 
 import util
 from BaseISCSI import BaseISCSISR
-import SR
-import SRCommand
 from shared_iscsi_test_base import ISCSITestCase
 from util import CommandException
-
+import xs_errors
 
 class TestBaseISCSI(ISCSITestCase):
 
@@ -102,7 +99,7 @@ class TestBaseISCSI(ISCSITestCase):
             target_iqn='iqn.2009-11.com.infinidat:storage:infinibox-sn-3393'))
 
         # Act
-        with self.assertRaises(SR.SROSError) as srose:
+        with self.assertRaises(xs_errors.SROSError) as srose:
             self.subject.attach(self.sr_uuid)
 
         # Assert

--- a/tests/test_BaseISCSI.py
+++ b/tests/test_BaseISCSI.py
@@ -85,7 +85,6 @@ class TestBaseISCSI(ISCSITestCase):
         self.subject.attach(self.sr_uuid)
 
     @mock.patch('BaseISCSI.BaseISCSISR._initPaths', autospec=True)
-    @mock.patch('BaseISCSI.xs_errors.XML_DEFS', "drivers/XE_SR_ERRORCODES.xml")
     def test_attach_tgt_present_path_not_found(self, mock_init_paths):
         # Arrange
         self.mock_util._testHost.return_value = None

--- a/tests/test_FileSR.py
+++ b/tests/test_FileSR.py
@@ -47,10 +47,6 @@ class TestFileVDI(unittest.TestCase):
         gethidden_patch = mock.patch('FileSR.vhdutil.getHidden')
         self.mock_gethidden = gethidden_patch.start()
 
-        errors_patcher = mock.patch('FileSR.xs_errors.XML_DEFS',
-                "drivers/XE_SR_ERRORCODES.xml")
-        errors_patcher.start()
-
         fist_patcher = mock.patch('FileSR.util.FistPoint.is_active',
                                   autospec=True)
         self.mock_fist = fist_patcher.start()
@@ -254,7 +250,8 @@ class TestFileVDI(unittest.TestCase):
             return real_stat(tgt)
 
         # Act
-        with self.assertRaises(xs_errors.SROSError) as srose, mock.patch('FileSR.os.stat') as mock_stat:
+        with self.assertRaises(xs_errors.SROSError), \
+                mock.patch('FileSR.os.stat') as mock_stat:
             mock_stat.side_effect = my_stat
             clone_xml = vdi.clone(sr_uuid, vdi_uuid)
 
@@ -301,7 +298,8 @@ class TestFileVDI(unittest.TestCase):
             return real_stat(tgt)
 
         # Act
-        with self.assertRaises(xs_errors.SROSError) as srose, mock.patch('FileSR.os.stat') as mock_stat:
+        with self.assertRaises(xs_errors.SROSError), \
+                mock.patch('FileSR.os.stat') as mock_stat:
             mock_stat.side_effect = my_stat
             clone_xml = vdi.clone(sr_uuid, vdi_uuid)
 
@@ -520,9 +518,7 @@ class TestShareFileSR(unittest.TestCase):
         self.mock_session.xenapi.message.create.assert_called_with(
             'sr_does_not_support_hardlinks', 2, "SR", self.sr_uuid, mock.ANY)
 
-    @testlib.with_context
-    def test_attach_not_writable(self, context):
-        context.setup_error_codes()
+    def test_attach_not_writable(self):
         test_sr = self.create_test_sr()
 
         with mock.patch('FileSR.open') as mock_open:
@@ -565,10 +561,6 @@ class TestFileSR(unittest.TestCase):
     def setUp(self):
         pread_patcher = mock.patch('FileSR.util.pread')
         self.mock_pread = pread_patcher.start()
-
-        errors_patcher = mock.patch('FileSR.xs_errors.XML_DEFS',
-                "drivers/XE_SR_ERRORCODES.xml")
-        errors_patcher.start()
 
         sr_init_patcher = mock.patch('SR.SR.__init__')
         def fake_sr_init(self, srcmd, sr_uuid):

--- a/tests/test_FileSR.py
+++ b/tests/test_FileSR.py
@@ -7,7 +7,6 @@ import uuid
 import xmlrpc.client
 
 from xml.dom.minidom import parseString
-import EXTSR
 
 import FileSR
 import SR
@@ -15,6 +14,7 @@ import SRCommand
 import testlib
 import util
 import vhdutil
+import xs_errors
 
 
 class FakeFileVDI(FileSR.FileVDI):
@@ -254,7 +254,7 @@ class TestFileVDI(unittest.TestCase):
             return real_stat(tgt)
 
         # Act
-        with self.assertRaises(SR.SROSError) as srose, mock.patch('FileSR.os.stat') as mock_stat:
+        with self.assertRaises(xs_errors.SROSError) as srose, mock.patch('FileSR.os.stat') as mock_stat:
             mock_stat.side_effect = my_stat
             clone_xml = vdi.clone(sr_uuid, vdi_uuid)
 
@@ -301,7 +301,7 @@ class TestFileVDI(unittest.TestCase):
             return real_stat(tgt)
 
         # Act
-        with self.assertRaises(SR.SROSError) as srose, mock.patch('FileSR.os.stat') as mock_stat:
+        with self.assertRaises(xs_errors.SROSError) as srose, mock.patch('FileSR.os.stat') as mock_stat:
             mock_stat.side_effect = my_stat
             clone_xml = vdi.clone(sr_uuid, vdi_uuid)
 
@@ -528,7 +528,7 @@ class TestShareFileSR(unittest.TestCase):
         with mock.patch('FileSR.open') as mock_open:
             mock_open.side_effect = OSError
 
-            with self.assertRaises(SR.SROSError) as cm:
+            with self.assertRaises(xs_errors.SROSError) as cm:
                 test_sr.attach(self.sr_uuid)
 
             self.assertEqual("The file system for SR cannot be written to.",
@@ -630,7 +630,7 @@ class TestFileSR(unittest.TestCase):
 
         sr.path = "pancakes"
 
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             sr.attach(None)
 
     @mock.patch("FileSR.util.makedirs", autospec=True)
@@ -644,7 +644,7 @@ class TestFileSR(unittest.TestCase):
         sr.path = "pancakes"
         sr.remotepath = "blueberries"
 
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             sr.attach(None)
 
     @mock.patch("FileSR.util.makedirs", autospec=True)

--- a/tests/test_HBASR.py
+++ b/tests/test_HBASR.py
@@ -145,8 +145,6 @@ class TestHBASR(unittest.TestCase):
         self.assertEqual(sr2.devs, "123445")
 
     @mock.patch('HBASR.HBASR.__init__', mock_init)
-    @mock.patch('LVHDoHBASR.xs_errors.XML_DEFS',
-                "drivers/XE_SR_ERRORCODES.xml")
     @mock.patch('HBASR.HBASR._probe_hba', autospec=True)
     @mock.patch('HBASR.xml.dom.minidom.parseString', autospec=True)
     def test__init_hbahostname_assert(self, mock_parseString, mock_probe_hba):
@@ -167,8 +165,6 @@ class TestHBASR(unittest.TestCase):
         self.assertEqual(res, "20-00-00-e0-8b-18-20-8b")
 
     @mock.patch('HBASR.HBASR.__init__', mock_init)
-    @mock.patch('LVHDoHBASR.xs_errors.XML_DEFS',
-                "drivers/XE_SR_ERRORCODES.xml")
     @mock.patch('HBASR.HBASR._probe_hba', autospec=True)
     @mock.patch('HBASR.xml.dom.minidom.parseString', autospec=True)
     def test__init_hbas_assert(self, mock_parseString, mock_probe_hba):
@@ -190,8 +186,6 @@ class TestHBASR(unittest.TestCase):
                                'host1': '50-01-43-80-24-26-ba-f4'})
 
     @mock.patch('HBASR.HBASR.__init__', mock_init)
-    @mock.patch('LVHDoHBASR.xs_errors.XML_DEFS',
-                "drivers/XE_SR_ERRORCODES.xml")
     @mock.patch('HBASR.util.pread', autospec=True)
     def test__probe_hba_assert(self, mock_pread):
         sr = HBASR.HBASR()
@@ -203,8 +197,6 @@ class TestHBASR(unittest.TestCase):
                          "[opterr=HBA probe failed]")
 
     @mock.patch('HBASR.HBASR.__init__', mock_init)
-    @mock.patch('LVHDoHBASR.xs_errors.XML_DEFS',
-                "drivers/XE_SR_ERRORCODES.xml")
     @mock.patch('HBASR.util.pread', autospec=True)
     @mock.patch('HBASR.util.listdir', autospec=True)
     def test__probe_hba(self, mock_listdir, mock_pread):

--- a/tests/test_HBASR.py
+++ b/tests/test_HBASR.py
@@ -4,6 +4,7 @@ import unittest
 import SR
 import xml.dom.minidom
 import util
+import xs_errors
 
 
 def mock_init(self):
@@ -152,7 +153,7 @@ class TestHBASR(unittest.TestCase):
         sr = HBASR.HBASR()
         mock_probe_hba.return_value = "blah"
         mock_parseString.side_effect = Exception("bad xml")
-        with self.assertRaises(SR.SROSError) as cm:
+        with self.assertRaises(xs_errors.SROSError) as cm:
             sr._init_hba_hostname()
         self.assertEqual(str(cm.exception),
                          "Unable to parse XML "
@@ -174,7 +175,7 @@ class TestHBASR(unittest.TestCase):
         sr = HBASR.HBASR()
         mock_probe_hba.return_value = "blah"
         mock_parseString.side_effect = Exception("bad xml")
-        with self.assertRaises(SR.SROSError) as cm:
+        with self.assertRaises(xs_errors.SROSError) as cm:
             sr._init_hbas()
         self.assertEqual(str(cm.exception),
                          "Unable to parse XML "
@@ -195,7 +196,7 @@ class TestHBASR(unittest.TestCase):
     def test__probe_hba_assert(self, mock_pread):
         sr = HBASR.HBASR()
         mock_pread.side_effect = Exception("bad")
-        with self.assertRaises(SR.SROSError) as cm:
+        with self.assertRaises(xs_errors.SROSError) as cm:
             sr._probe_hba()
         self.assertEqual(str(cm.exception),
                          "Unable to parse XML "

--- a/tests/test_ISOSR.py
+++ b/tests/test_ISOSR.py
@@ -9,6 +9,7 @@ import os
 import sys
 import tempfile
 import testlib
+import xs_errors
 
 
 class FakeISOSR(ISOSR.ISOSR):
@@ -154,9 +155,9 @@ class TestISOSR_overNFS(unittest.TestCase):
                                   sr_uuid='asr_uuid')
 
         _checkmount.side_effect = [False]
-        testHost.side_effect = SR.SROSError(140, 'Incorrect DNS name, unable to resolve.')
+        testHost.side_effect = xs_errors.SROSError(140, 'Incorrect DNS name, unable to resolve.')
 
-        with self.assertRaises(SR.SROSError) as ose:
+        with self.assertRaises(xs_errors.SROSError) as ose:
             isosr.attach(None)
 
         self.assertEqual(140, ose.exception.errno)
@@ -183,7 +184,7 @@ class TestISOSR_overNFS(unittest.TestCase):
         validate_nfsversion.return_value = '4'
         check_server_tcp.return_value = False
 
-        with self.assertRaises(SR.SROSError) as cm:
+        with self.assertRaises(xs_errors.SROSError) as cm:
             isosr.attach(None)
 
         self.assertRegex(str(cm.exception),
@@ -387,7 +388,7 @@ class TestISOSR_overSMB(unittest.TestCase):
         context.setup_error_codes()
         smbsr = self.create_smbisosr(atype='cifs', vers='2.0')
         raised_exception = None
-        with self.assertRaises(SR.SROSError) as context:
+        with self.assertRaises(xs_errors.SROSError) as context:
             smbsr.attach(None)
         self.assertEqual(context.exception.errno, 227)
         self.assertEqual(
@@ -407,7 +408,7 @@ class TestISOSR_overSMB(unittest.TestCase):
         """
         context.setup_error_codes()
         smbsr = self.create_smbisosr(options='-o vers=2.0')
-        with self.assertRaises(SR.SROSError) as context:
+        with self.assertRaises(xs_errors.SROSError) as context:
             smbsr.attach(None)
         self.assertEqual(context.exception.errno, 227)
         self.assertEqual(
@@ -456,7 +457,7 @@ class TestISOSR_overSMB(unittest.TestCase):
         pread.side_effect = iter([util.CommandException(errno.EHOSTDOWN), \
                 util.CommandException(errno.EHOSTDOWN), util.CommandException(errno.EHOSTDOWN)])
         _checkmount.side_effect = [False, True]
-        with self.assertRaises(SR.SROSError) as context:
+        with self.assertRaises(xs_errors.SROSError) as context:
             smbsr.attach(None)
         self.assertEqual(context.exception.errno, 222)
         self.assertEqual(
@@ -514,7 +515,7 @@ class TestISOSR_overSMB(unittest.TestCase):
         smbsr = self.create_smbisosr(atype='cifs')
         find_my_pbd.return_value = None
         _checkmount.side_effect = [False, True]
-        with self.assertRaises(SR.SROSError) as exp:
+        with self.assertRaises(xs_errors.SROSError) as exp:
             smbsr.attach(None)
         self.assertEqual(exp.exception.errno, context.get_error_code("SMBMount"))
 

--- a/tests/test_ISOSR.py
+++ b/tests/test_ISOSR.py
@@ -155,14 +155,14 @@ class TestISOSR_overNFS(unittest.TestCase):
                                   sr_uuid='asr_uuid')
 
         _checkmount.side_effect = [False]
-        testHost.side_effect = xs_errors.SROSError(140, 'Incorrect DNS name, unable to resolve.')
+        testHost.side_effect = xs_errors.SROSError(
+            140, 'Incorrect DNS name, unable to resolve.')
 
         with self.assertRaises(xs_errors.SROSError) as ose:
             isosr.attach(None)
 
         self.assertEqual(140, ose.exception.errno)
 
-    @testlib.with_context
     @mock.patch('util.gen_uuid', autospec=True)
     @mock.patch('nfs.soft_mount', autospec=True)
     @mock.patch('util._convertDNS', autospec=True)
@@ -173,10 +173,8 @@ class TestISOSR_overNFS(unittest.TestCase):
     # Can't use autospec due to http://bugs.python.org/issue17826
     @mock.patch('ISOSR.ISOSR._checkmount')
     def test_attach_nfs_wrong_version(
-            self, context, _checkmount, check_server_tcp, testHost, makedirs,
+            self, _checkmount, check_server_tcp, testHost, makedirs,
             validate_nfsversion, convertDNS, soft_mount, gen_uuid):
-        context.setup_error_codes()
-
         isosr = self.create_isosr(location='aServer:/aLocation', atype='nfs_iso',
                                   sr_uuid='asr_uuid')
 
@@ -231,7 +229,6 @@ class TestISOSR_overSMB(unittest.TestCase):
         """
         Positive case, over XC/XE CLI with version 1.0.
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(atype='cifs', vers='1.0')
         _checkmount.side_effect = [False, True]
         smbsr.attach(None)
@@ -250,7 +247,6 @@ class TestISOSR_overSMB(unittest.TestCase):
         """
         Positive case, over XC/XE CLI with version 1.0.
         """
-        context.setup_error_codes()
         update = {'username': 'dot', 'cifspassword': 'winter2019'}
         smbsr = self.create_smbisosr(atype='cifs', vers='1.0',
                                      dconf_update=update)
@@ -272,7 +268,6 @@ class TestISOSR_overSMB(unittest.TestCase):
         """
         Positive case, over XC/XE CLI with version 1.0.
         """
-        context.setup_error_codes()
         update = {'username': r'citrix\jsmith', 'cifspassword': 'winter2019'}
         smbsr = self.create_smbisosr(atype='cifs', vers='1.0',
                                      dconf_update=update)
@@ -293,7 +288,6 @@ class TestISOSR_overSMB(unittest.TestCase):
         """
         Positive case, over XC/XE CLI with version 3.0.
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(atype='cifs', vers='3.0')
         _checkmount.side_effect = [False, True]
         smbsr.attach(None)
@@ -314,7 +308,6 @@ class TestISOSR_overSMB(unittest.TestCase):
         """
         Positive case, over XC/XE CLI without version.
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(atype='cifs')
         _checkmount.side_effect = [False, True]
         smbsr.attach(None)
@@ -333,7 +326,6 @@ class TestISOSR_overSMB(unittest.TestCase):
         """
         Positive case, over xe-sr-mount CLI with version 1.0.
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(options='-o username=administrator,password=password,vers=1.0')
         smbsr.attach(None)
         self.assertEqual(0, pread.call_count)
@@ -350,7 +342,6 @@ class TestISOSR_overSMB(unittest.TestCase):
         """
         Positive case, over xe-sr-mount CLI with version 3.0.
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(options='-o username=administrator,password=password,vers=3.0')
         smbsr.attach(None)
         self.assertEqual(0, pread.call_count)
@@ -370,24 +361,20 @@ class TestISOSR_overSMB(unittest.TestCase):
         """
         Positive case, without version from xe-sr-mount.
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(options='-o username=administrator,password=password')
         smbsr.attach(None)
         self.assertEqual(0, pread.call_count)
 
-    @testlib.with_context
     @mock.patch('util.gen_uuid')
     @mock.patch('util.makedirs')
     @mock.patch('ISOSR.ISOSR._checkTargetStr')
     @mock.patch('util.pread', autospec=True)
-    def test_attach_smb_wrongversion(self, context, pread, _checkTargetStr,
+    def test_attach_smb_wrongversion(self, pread, _checkTargetStr,
                                      makedirs, gen_uuid):
         """
         Unsupported version from XC/XE CLI.
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(atype='cifs', vers='2.0')
-        raised_exception = None
         with self.assertRaises(xs_errors.SROSError) as context:
             smbsr.attach(None)
         self.assertEqual(context.exception.errno, 227)
@@ -396,17 +383,15 @@ class TestISOSR_overSMB(unittest.TestCase):
             'Given SMB version is not allowed. Choose either 1.0 or 3.0'
         )
 
-    @testlib.with_context
     @mock.patch('util.gen_uuid')
     @mock.patch('util.makedirs')
     @mock.patch('ISOSR.ISOSR._checkTargetStr')
-    def test_attach_smb_wrongversion_via_xemount(self, context,
+    def test_attach_smb_wrongversion_via_xemount(self,
                                                  _checkTargetStr, makedirs,
                                                  gen_uuid):
         """
         Unsupported version from xe-sr-mount.
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(options='-o vers=2.0')
         with self.assertRaises(xs_errors.SROSError) as context:
             smbsr.attach(None)
@@ -428,7 +413,6 @@ class TestISOSR_overSMB(unittest.TestCase):
         """
         Fall back scenario from XC/XE CLI with smb3 diabled and smb1 enabled.
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(atype='cifs')
         pread.side_effect = iter([util.CommandException(errno.EHOSTDOWN), " "])
         _checkmount.side_effect = [False, True]
@@ -437,13 +421,12 @@ class TestISOSR_overSMB(unittest.TestCase):
                                   '/var/run/sr-mount/asr_uuid', '-o',
                                   'cache=none,guest,vers=1.0'], True, new_env=None)
 
-    @testlib.with_context
     @mock.patch('util.gen_uuid')
     @mock.patch('util.makedirs')
     @mock.patch('ISOSR.ISOSR._checkTargetStr')
     @mock.patch('util.pread', autospec=True)
     @mock.patch('ISOSR.ISOSR._checkmount')
-    def test_attach_smb_version_fallback_with_smb_1_3_disabled(self, context,
+    def test_attach_smb_version_fallback_with_smb_1_3_disabled(self,
                                                                _checkmount,
                                                                pread,
                                                                _checkTargetStr,
@@ -452,7 +435,6 @@ class TestISOSR_overSMB(unittest.TestCase):
         """
         Fall back scenario from XC/XE CLI with smb3 diabled and smb1 disabled.
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(atype='cifs')
         pread.side_effect = iter([util.CommandException(errno.EHOSTDOWN), \
                 util.CommandException(errno.EHOSTDOWN), util.CommandException(errno.EHOSTDOWN)])
@@ -465,20 +447,18 @@ class TestISOSR_overSMB(unittest.TestCase):
             'Could not mount the directory specified in Device Configuration [opterr=exec failed]'
         )
 
-    @testlib.with_context
     @mock.patch('util.gen_uuid')
     @mock.patch('util.makedirs')
     @mock.patch('ISOSR.ISOSR._checkTargetStr')
     @mock.patch('util.pread', autospec=True)
     @mock.patch('ISOSR.ISOSR._checkmount')
-    def test_attach_smb_via_xemount_no_version_fallback(self, context,
+    def test_attach_smb_via_xemount_no_version_fallback(self,
                                                         _checkmount, pread,
                                                         _checkTargetStr,
                                                         makedirs, gen_uuid):
         """
         Fall back scenario from xe-sr-mount with smb3 diabled and smb1 enabled.
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(options='-o username=administrator,password=password')
         pread.side_effect = iter([util.CommandException(errno.EHOSTDOWN), " "])
 
@@ -493,7 +473,6 @@ class TestISOSR_overSMB(unittest.TestCase):
         """
         Fall back scenario negative case from xe-sr-mount with smb3 diabled and smb1 disabled.
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(atype='cifs')
         pread.side_effect = iter([util.CommandException(errno.EHOSTDOWN),
                              util.CommandException(errno.EHOSTDOWN)])
@@ -501,23 +480,22 @@ class TestISOSR_overSMB(unittest.TestCase):
         with self.assertRaises(Exception):
             smbsr.attach(None)
 
-    @testlib.with_context
     @mock.patch('util.makedirs')
     @mock.patch('ISOSR.ISOSR._checkTargetStr')
     @mock.patch('util.pread', autospec=True)
     @mock.patch('util.find_my_pbd')
     @mock.patch('ISOSR.ISOSR._checkmount')
-    def test_mountoversmb_will_raise_on_error(self, context, _checkmount, find_my_pbd, pread, _checkTargetStr, makedirs):
+    def test_mountoversmb_will_raise_on_error(
+            self, _checkmount, find_my_pbd, pread, _checkTargetStr, makedirs):
         """
         Test failure to store SMB version inside PBD config will raise exception
         """
-        context.setup_error_codes()
         smbsr = self.create_smbisosr(atype='cifs')
         find_my_pbd.return_value = None
         _checkmount.side_effect = [False, True]
         with self.assertRaises(xs_errors.SROSError) as exp:
             smbsr.attach(None)
-        self.assertEqual(exp.exception.errno, context.get_error_code("SMBMount"))
+        self.assertEqual(exp.exception.errno, 111)
 
 
 class TestISOSR_functions(unittest.TestCase):

--- a/tests/test_LVHDoFCoESR.py
+++ b/tests/test_LVHDoFCoESR.py
@@ -1,8 +1,8 @@
 import unittest.mock as mock
 import LVHDoFCoESR
-import SR
 import unittest
 import testlib
+import xs_errors
 
 
 class FakeFCoESR(LVHDoFCoESR.LVHDoFCoESR):
@@ -47,7 +47,7 @@ class TestFCoESR(unittest.TestCase):
         find_my_pbd.return_value = ['pbd_ref', 'pbd']
         parameters = {}
         parameters['device_config'] = ""
-        self.assertRaises(SR.SROSError, self.create_fcoesr, SCSIid="", params=parameters)
+        self.assertRaises(xs_errors.SROSError, self.create_fcoesr, SCSIid="", params=parameters)
 
     @mock.patch('SR.driver', autospec=True)
     @mock.patch('util.find_my_pbd', autospec=True)

--- a/tests/test_LVHDoFCoESR.py
+++ b/tests/test_LVHDoFCoESR.py
@@ -41,13 +41,12 @@ class TestFCoESR(unittest.TestCase):
     @mock.patch('SR.driver', autospec=True)
     @mock.patch('util.find_my_pbd', autospec=True)
     @mock.patch('LVHDoFCoESR.LVHDoHBASR.HBASR.HBASR.print_devs', autospec=True)
-    @testlib.with_context
-    def test_load_no_scsiid(self, context, print_devs, find_my_pbd, driver):
-        context.setup_error_codes()
+    def test_load_no_scsiid(self, print_devs, find_my_pbd, driver):
         find_my_pbd.return_value = ['pbd_ref', 'pbd']
         parameters = {}
         parameters['device_config'] = ""
-        self.assertRaises(xs_errors.SROSError, self.create_fcoesr, SCSIid="", params=parameters)
+        self.assertRaises(xs_errors.SROSError, self.create_fcoesr,
+                          SCSIid="", params=parameters)
 
     @mock.patch('SR.driver', autospec=True)
     @mock.patch('util.find_my_pbd', autospec=True)

--- a/tests/test_LVHDoHBASR.py
+++ b/tests/test_LVHDoHBASR.py
@@ -2,10 +2,11 @@ import unittest.mock as mock
 import LVHDoHBASR
 import unittest
 import xmlrpc.client
-import SR
 import SRCommand
+import xs_errors
 
 from uuid import uuid4
+
 
 def mock_init(self, sr, sr_uuid):
     self.sr = sr
@@ -66,7 +67,7 @@ class TestLVHDoHBAVDI(unittest.TestCase):
         vdi = LVHDoHBASR.LVHDoHBAVDI(sr, sr_uuid)
         vdi.path = "blahblah"
 
-        with self.assertRaises(SR.SROSError) as cm:
+        with self.assertRaises(xs_errors.SROSError) as cm:
             stuff = vdi.generate_config(sr_uuid, vdi_uuid)
 
         self.assertEqual(str(cm.exception), "The VDI is not available")

--- a/tests/test_LVHDoHBASR.py
+++ b/tests/test_LVHDoHBASR.py
@@ -47,8 +47,6 @@ class TestLVHDoHBAVDI(unittest.TestCase):
                          mpath_handle)
 
     @mock.patch('LVHDoHBASR.LVHDoHBASR', autospec=True)
-    @mock.patch('LVHDoHBASR.xs_errors.XML_DEFS',
-                "drivers/XE_SR_ERRORCODES.xml")
     @mock.patch('LVHDoHBASR.LVHDoHBAVDI.__init__', mock_init)
     @mock.patch('LVHDoHBASR.lvutil._checkLV', autospec=True)
     def test_generate_config_bad_path_assert(self,
@@ -125,8 +123,6 @@ class TestLVHDoHBASR(unittest.TestCase):
             srcmd.parse()
         return srcmd
 
-    @mock.patch('LVHDoHBASR.xs_errors.XML_DEFS',
-                "drivers/XE_SR_ERRORCODES.xml")
     @mock.patch("builtins.open", new_callable=mock.mock_open())
     @mock.patch('LVHDoHBASR.glob.glob', autospec=True)
     def test_sr_delete_no_multipath(self, mock_glob, mock_open):

--- a/tests/test_LVHDoISCSISR.py
+++ b/tests/test_LVHDoISCSISR.py
@@ -97,7 +97,7 @@ class TestLVHDoISCSISR_load(unittest.TestCase):
             'Raise XenError'
         )
 
-        with self.assertRaises(SR.SROSError) as cm:
+        with self.assertRaises(xs_errors.SROSError) as cm:
             self.lvhd_o_iscsi_sr.load(self.fake_uuid)
 
         self.assertEqual(cm.exception.errno, 70)
@@ -118,7 +118,7 @@ class TestLVHDoISCSISR_load(unittest.TestCase):
             'Raise RandomError'
         )
 
-        with self.assertRaises(SR.SROSError) as cm:
+        with self.assertRaises(xs_errors.SROSError) as cm:
             self.lvhd_o_iscsi_sr.load(self.fake_uuid)
 
         self.assertEqual(cm.exception.errno, 202)

--- a/tests/test_LVHDoISCSISR.py
+++ b/tests/test_LVHDoISCSISR.py
@@ -85,13 +85,9 @@ class TestLVHDoISCSISR_load(unittest.TestCase):
         self.addCleanup(mock.patch.stopall)
 
     @mock.patch('iscsilib.ensure_daemon_running_ok')
-    @testlib.with_context
     def test_1st_try_block_raise_XenError(
             self,
-            context,
             mock_iscsilib_ensure_daemon_running_ok):
-        context.setup_error_codes()
-
         mock_iscsilib_ensure_daemon_running_ok.side_effect = xs_errors.XenError(
             'ISCSIInitiator',
             'Raise XenError'
@@ -107,13 +103,9 @@ class TestLVHDoISCSISR_load(unittest.TestCase):
         )
 
     @mock.patch('iscsilib.ensure_daemon_running_ok')
-    @testlib.with_context
     def test_1st_try_block_raise_RandomError(
             self,
-            context,
             mock_iscsilib_ensure_daemon_running_ok):
-        context.setup_error_codes()
-
         mock_iscsilib_ensure_daemon_running_ok.side_effect = RandomError(
             'Raise RandomError'
         )

--- a/tests/test_NFSSR.py
+++ b/tests/test_NFSSR.py
@@ -7,6 +7,7 @@ import unittest
 from uuid import uuid4
 
 import util
+import xs_errors
 
 
 class FakeNFSSR(NFSSR.NFSSR):
@@ -107,7 +108,7 @@ class TestNFSSR(unittest.TestCase):
         makedirs.side_effect = mock_makedirs
 
         # Act
-        with self.assertRaises(SR.SROSError) as srose:
+        with self.assertRaises(xs_errors.SROSError) as srose:
             nfssr.create(sr_uuid, size)
 
         self.assertEqual(srose.exception.errno, 461)
@@ -135,7 +136,7 @@ class TestNFSSR(unittest.TestCase):
         makedirs.side_effect = mock_makedirs
 
         # Act
-        with self.assertRaises(SR.SROSError) as srose:
+        with self.assertRaises(xs_errors.SROSError) as srose:
             nfssr.create(sr_uuid, size)
 
         self.assertEqual(srose.exception.errno, 88)
@@ -162,7 +163,7 @@ class TestNFSSR(unittest.TestCase):
 
         sr_uuid = str(uuid4())
         size = 100
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             nfssr.create(sr_uuid, size)
 
     @mock.patch('FileSR.SharedFileSR._check_writable', autospec=True)
@@ -202,11 +203,11 @@ class TestNFSSR(unittest.TestCase):
     @mock.patch('nfs.validate_nfsversion', autospec=True)
     def test_attach_failure(self, validate_nfsversion, check_server_tcp,
                             _testhost, unmount, soft_mount, Lock, makedirs):
-        soft_mount.side_effect = SR.SRException("aFailure")
+        soft_mount.side_effect = xs_errors.SRException("aFailure")
 
         nfssr = self.create_nfssr()
 
-        with self.assertRaises(SR.SRException):
+        with self.assertRaises(xs_errors.SRException):
             nfssr.attach(None)
 
         unmount.assert_not_called()
@@ -255,11 +256,11 @@ class TestNFSSR(unittest.TestCase):
         mock_checkmount.side_effect = lambda *args: is_mounted()
         soft_mount.side_effect = fake_soft_mount
         unmount.side_effect = fake_unmount
-        mock_checkwritable.side_effect = SR.SRException("aFailure")
+        mock_checkwritable.side_effect = xs_errors.SRException("aFailure")
 
         nfssr = self.create_nfssr(sr_uuid='UUID')
 
-        with self.assertRaises(SR.SRException):
+        with self.assertRaises(xs_errors.SRException):
             nfssr.attach(None)
 
         soft_mount.assert_called_once()

--- a/tests/test_NFSSR.py
+++ b/tests/test_NFSSR.py
@@ -92,7 +92,6 @@ class TestNFSSR(unittest.TestCase):
     @mock.patch('util._testHost')
     @mock.patch('nfs.check_server_tcp')
     @mock.patch('nfs.validate_nfsversion')
-    @mock.patch('SR.xs_errors.XML_DEFS', "drivers/XE_SR_ERRORCODES.xml")
     def test_sr_create_readonly(self, validate_nfsversion, check_server_tcp, _testhost,
                        soft_mount, Lock, makedirs):
         # Arrange
@@ -119,7 +118,6 @@ class TestNFSSR(unittest.TestCase):
     @mock.patch('util._testHost')
     @mock.patch('nfs.check_server_tcp')
     @mock.patch('nfs.validate_nfsversion')
-    @mock.patch('SR.xs_errors.XML_DEFS', "drivers/XE_SR_ERRORCODES.xml")
     def test_sr_create_noperm(self, validate_nfsversion, check_server_tcp, _testhost,
                        soft_mount, Lock, makedirs):
         # Arrange
@@ -148,8 +146,6 @@ class TestNFSSR(unittest.TestCase):
     @mock.patch('util._testHost')
     @mock.patch('nfs.check_server_tcp')
     @mock.patch('nfs.validate_nfsversion')
-    @mock.patch('NFSSR.xs_errors.XML_DEFS',
-                'drivers/XE_SR_ERRORCODES.xml')
     def test_sr_create_mount_error(
             self, validate_nfsversion, check_server_tcp, _testhost,
             soft_mount, Lock, mock_rmdir):

--- a/tests/test_SMBSR.py
+++ b/tests/test_SMBSR.py
@@ -71,13 +71,11 @@ class Test_SMBSR(unittest.TestCase):
         return smbsr
 
     #Attach
-    @testlib.with_context
     @mock.patch('SMBSR.SMBSR.checkmount', autospec=True)
     @mock.patch('SMBSR.SMBSR.mount', autospec=True)
     @mock.patch('SMBSR.Lock', autospec=True)
-    def test_attach_smbexception_raises_xenerror(self, context, mock_lock, mock_mount, mock_checkmount):
-        context.setup_error_codes()
-
+    def test_attach_smbexception_raises_xenerror(
+            self, mock_lock, mock_mount, mock_checkmount):
         smbsr = self.create_smbsr()
         mock_mount.side_effect = SMBSR.SMBException("mount raised SMBException")
         mock_checkmount.return_value = False
@@ -218,15 +216,14 @@ class Test_SMBSR(unittest.TestCase):
         mock_unlink.assert_not_called()
 
     #Detach
-    @testlib.with_context
     @mock.patch('SMBSR.SMBSR.checkmount', return_value=True, autospec=True)
     @mock.patch('SMBSR.SMBSR.unmount', autospec=True)
     @mock.patch('SMBSR.Lock', autospec=True)
     @mock.patch('SMBSR.os.chdir', autospec=True)
     @mock.patch('SMBSR.cleanup', autospec=True)
-    def test_detach_smbexception_raises_xenerror(self, context, mock_cleanup, mock_chdir, mock_lock, mock_unmount, mock_checkmount):
-        context.setup_error_codes()
-
+    def test_detach_smbexception_raises_xenerror(
+            self, mock_cleanup, mock_chdir, mock_lock,
+            mock_unmount, mock_checkmount):
         smbsr = self.create_smbsr()
         mock_unmount.side_effect = SMBSR.SMBException("unmount raised SMBException")
         with self.assertRaises(xs_errors.SROSError) as cm:
@@ -286,7 +283,6 @@ class Test_SMBSR(unittest.TestCase):
     @mock.patch('util.get_pool_restrictions', autospec=True)
     @mock.patch('SMBSR.Lock', autospec=True)
     @mock.patch('SMBSR.os.symlink', autospec=True)
-    @mock.patch('SR.xs_errors.XML_DEFS', "drivers/XE_SR_ERRORCODES.xml")
     def test_create_read_only(self, symlink, lock, restrict, makedirs):
         # Arrange
         smbsr = self.create_smbsr()
@@ -316,7 +312,6 @@ class Test_SMBSR(unittest.TestCase):
     @mock.patch('util.get_pool_restrictions', autospec=True)
     @mock.patch('SMBSR.Lock', autospec=True)
     @mock.patch('SMBSR.os.symlink', autospec=True)
-    @mock.patch('SR.xs_errors.XML_DEFS', "drivers/XE_SR_ERRORCODES.xml")
     def test_create_nospace(self, symlink, lock, restrict, makedirs):
         # Arrange
         smbsr = self.create_smbsr()

--- a/tests/test_SMBSR.py
+++ b/tests/test_SMBSR.py
@@ -8,6 +8,7 @@ import testlib
 import util
 import errno
 import XenAPI
+import xs_errors
 
 
 class FakeSMBSR(SMBSR.SMBSR):
@@ -80,7 +81,7 @@ class Test_SMBSR(unittest.TestCase):
         smbsr = self.create_smbsr()
         mock_mount.side_effect = SMBSR.SMBException("mount raised SMBException")
         mock_checkmount.return_value = False
-        with self.assertRaises(SR.SROSError) as cm:
+        with self.assertRaises(xs_errors.SROSError) as cm:
             smbsr.attach('asr_uuid')
         # Check that we get the SMBMount error from XE_SR_ERRORCODES.xml
         self.assertEqual(cm.exception.errno, 111)
@@ -187,10 +188,10 @@ class Test_SMBSR(unittest.TestCase):
         mock_pathexists.side_effect = lambda *args: link_exists()
         mock_symlink.side_effect = fake_symlink
         mock_unlink.side_effect = fake_unlink
-        mock_checkwritable.side_effect = SR.SRException("aFailure")
+        mock_checkwritable.side_effect = xs_errors.SRException("aFailure")
 
         smbsr = self.create_smbsr()
-        with self.assertRaises(SR.SRException):
+        with self.assertRaises(xs_errors.SRException):
             smbsr.attach('asr_uuid')
         mock_mount.assert_called_once()
         mock_unmount.assert_called_once_with(smbsr, smbsr.mountpoint, True)
@@ -228,7 +229,7 @@ class Test_SMBSR(unittest.TestCase):
 
         smbsr = self.create_smbsr()
         mock_unmount.side_effect = SMBSR.SMBException("unmount raised SMBException")
-        with self.assertRaises(SR.SROSError) as cm:
+        with self.assertRaises(xs_errors.SROSError) as cm:
             smbsr.detach('asr_uuid')
         # Check that we get the SMBUnMount error from XE_SR_ERRORCODES.xml
         self.assertEqual(cm.exception.errno, 112)
@@ -303,7 +304,7 @@ class Test_SMBSR(unittest.TestCase):
         makedirs.side_effect = mock_makedirs
 
         # Act
-        with self.assertRaises(SR.SROSError) as srose:
+        with self.assertRaises(xs_errors.SROSError) as srose:
             smbsr.create(sr_uuid, 10 * 1024 * 1024 * 1024)
 
         # Assert
@@ -333,7 +334,7 @@ class Test_SMBSR(unittest.TestCase):
         makedirs.side_effect = mock_makedirs
 
         # Act
-        with self.assertRaises(SR.SROSError) as srose:
+        with self.assertRaises(xs_errors.SROSError) as srose:
             smbsr.create(sr_uuid, 10 * 1024 * 1024 * 1024)
 
         # Assert

--- a/tests/test_SR.py
+++ b/tests/test_SR.py
@@ -2,6 +2,7 @@ import unittest
 import unittest.mock as mock
 import SR
 from SR import deviceCheck
+import xs_errors
 
 
 class TestSR(unittest.TestCase):
@@ -46,7 +47,7 @@ class TestSR(unittest.TestCase):
         """
         checker = TestSR.deviceTest()
 
-        with self.assertRaises(SR.SROSError) as sre:
+        with self.assertRaises(xs_errors.SROSError) as sre:
             checker.verify()
 
     @mock.patch('SR.SR.scan', autospec=True)
@@ -73,7 +74,7 @@ class TestSR(unittest.TestCase):
         sr1 = self.create_SR("sr_create", {'ISCSIid': '12333423'},
             {'session_ref': 'session1'})
 
-        mock_scan.side_effect = SR.SROSError(46, "The VDI is not available")
+        mock_scan.side_effect = xs_errors.SROSError(46, "The VDI is not available")
 
         sr1.after_master_attach('dummy uuid')
 

--- a/tests/test_SR.py
+++ b/tests/test_SR.py
@@ -40,14 +40,13 @@ class TestSR(unittest.TestCase):
 
         checker.verify()
 
-    @mock.patch('SR.xs_errors.XML_DEFS', "drivers/XE_SR_ERRORCODES.xml")
     def test_device_check_nodevice(self):
         """
         Test the device check decorator with no device configured
         """
         checker = TestSR.deviceTest()
 
-        with self.assertRaises(xs_errors.SROSError) as sre:
+        with self.assertRaises(xs_errors.SROSError):
             checker.verify()
 
     @mock.patch('SR.SR.scan', autospec=True)
@@ -74,7 +73,8 @@ class TestSR(unittest.TestCase):
         sr1 = self.create_SR("sr_create", {'ISCSIid': '12333423'},
             {'session_ref': 'session1'})
 
-        mock_scan.side_effect = xs_errors.SROSError(46, "The VDI is not available")
+        mock_scan.side_effect = xs_errors.SROSError(
+            46, "The VDI is not available")
 
         sr1.after_master_attach('dummy uuid')
 

--- a/tests/test_SRCommand.py
+++ b/tests/test_SRCommand.py
@@ -62,7 +62,8 @@ class TestStandaloneFunctions(unittest.TestCase):
             mock_run_statics,
             mock_logException):
 
-        """ If an SRException is thrown, assert that print <SRException instance>.toxml()" is called.
+        """ If an SRException is thrown, assert that print
+         <SRException instance>.toxml() is called.
         """
 
         import sys

--- a/tests/test_SRCommand.py
+++ b/tests/test_SRCommand.py
@@ -62,12 +62,12 @@ class TestStandaloneFunctions(unittest.TestCase):
             mock_run_statics,
             mock_logException):
 
-        """ If an SR.SRException is thrown, assert that print <SR.SRException instance>.toxml()" is called.
+        """ If an SRException is thrown, assert that print <SRException instance>.toxml()" is called.
         """
 
         import sys
         from io import StringIO
-        from SR import SRException
+        from xs_errors import SRException
         from DummySR import DRIVER_INFO
 
         # Save original sys.stdout file object.

--- a/tests/test_blktap2.py
+++ b/tests/test_blktap2.py
@@ -8,9 +8,9 @@ import sys
 import syslog
 import uuid
 
-import SR
 import blktap2
 import util
+import xs_errors
 
 
 class BogusException(Exception):
@@ -103,7 +103,7 @@ class TestTapdisk(unittest.TestCase):
         self.mock_tapctl.spawn.return_value = 123
         self.mock_tapctl.open.side_effect = no_medium
 
-        with self.assertRaises(SR.SROSError) as srose:
+        with self.assertRaises(xs_errors.SROSError) as srose:
             blktap2.Tapdisk.launch_on_tap(
                 blktap, "/dev/sr0", "not used", "not used")
 

--- a/tests/test_blktap2.py
+++ b/tests/test_blktap2.py
@@ -89,7 +89,6 @@ class TestTapdisk(unittest.TestCase):
                          results[0].path)
         self.assertEqual('vhd', results[0].type)
 
-    @mock.patch('SR.xs_errors.XML_DEFS', "drivers/XE_SR_ERRORCODES.xml")
     @mock.patch('blktap2.Tapdisk.cgclassify')
     def test_open_empty_cd(self, mock_cgclassify):
         blktap = mock.MagicMock()

--- a/tests/test_cbt.py
+++ b/tests/test_cbt.py
@@ -80,8 +80,6 @@ class TestCBT(unittest.TestCase):
     @mock.patch('blktap2.VDI', autospec=True)
     @mock.patch('VDI.VDI._cbt_op', autospec=True)
     def test_configure_blocktracking_enable_success(self, context, mock_cbt, mock_bt_vdi):
-        context.setup_error_codes()
-
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, False)
@@ -94,8 +92,6 @@ class TestCBT(unittest.TestCase):
     @mock.patch('blktap2.VDI', autospec=True)
     @mock.patch('VDI.cbtutil', autospec=True)
     def test_configure_blocktracking_enable_already_enabled(self, context, mock_cbt, mock_bt_vdi):
-        context.setup_error_codes()
-
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, True)
@@ -112,8 +108,6 @@ class TestCBT(unittest.TestCase):
     @mock.patch('lock.LockImplementation')
     def test_configure_blocktracking_disable_when_enabled_without_parent(
             self, context, mock_lock, mock_cbt, mock_logchecker, mock_bt_vdi):
-        context.setup_error_codes()
-
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
 
@@ -130,8 +124,6 @@ class TestCBT(unittest.TestCase):
     @mock.patch('lock.LockImplementation')
     def test_configure_blocktracking_disable_when_enabled_with_parent(
             self, context, mock_lock, mock_logcheck, mock_cbt, mock_bt_vdi):
-        context.setup_error_codes()
-
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
 
@@ -153,8 +145,6 @@ class TestCBT(unittest.TestCase):
     @testlib.with_context
     @mock.patch('blktap2.VDI', autospec=True)
     def test_configure_blocktracking_disable_already_disabled(self, context, mock_bt_vdi):
-        context.setup_error_codes()
-
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
 
@@ -165,10 +155,7 @@ class TestCBT(unittest.TestCase):
         self._check_setting_not_changed()
         self._check_tapdisk_not_modified(mock_bt_vdi)
 
-    @testlib.with_context
-    def test_configure_blocktracking_enable_raw_vdi(self, context):
-        context.setup_error_codes()
-
+    def test_configure_blocktracking_enable_raw_vdi(self):
         # Create the test object
         self.vdi = VDI.VDI(self.sr, self.vdi_uuid)
         self.vdi.path = "/mock/sr_path/" + str(self.vdi_uuid)
@@ -176,10 +163,7 @@ class TestCBT(unittest.TestCase):
         with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, True)
 
-    @testlib.with_context
-    def test_configure_blocktracking_enable_snapshot(self, context):
-        context.setup_error_codes()
-
+    def test_configure_blocktracking_enable_snapshot(self):
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self.xenapi.VDI.get_is_a_snapshot.return_value = True
@@ -187,13 +171,11 @@ class TestCBT(unittest.TestCase):
         with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, True)
 
-    @testlib.with_context
     @mock.patch('blktap2.VDI', autospec=True)
     @mock.patch('VDI.util', autospec=True)
     @mock.patch('VDI.cbtutil', autospec=True)
-    def test_configure_blocktracking_enable_pause_fail(self, context, mock_cbt, mock_util, mock_bt_vdi):
-        context.setup_error_codes()
-
+    def test_configure_blocktracking_enable_pause_fail(
+            self, mock_cbt, mock_util, mock_bt_vdi):
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
 
@@ -203,12 +185,10 @@ class TestCBT(unittest.TestCase):
         with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, True)
 
-    @testlib.with_context
     @mock.patch('blktap2.VDI', autospec=True)
     @mock.patch('VDI.util', autospec=True)
-    def test_configure_blocktracking_disable_pause_fail(self, context, mock_util, mock_bt_vdi):
-        context.setup_error_codes()
-
+    def test_configure_blocktracking_disable_pause_fail(
+            self, mock_util, mock_bt_vdi):
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
 
@@ -218,11 +198,8 @@ class TestCBT(unittest.TestCase):
         with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, False)
 
-    @testlib.with_context
     @mock.patch('VDI.util', autospec=True)
-    def test_configure_blocktracking_enable_metadata_no_space(self, context, mock_util):
-        context.setup_error_codes()
-
+    def test_configure_blocktracking_enable_metadata_no_space(self, mock_util):
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self.vdi.state_mock._ensure_cbt_space.side_effect = [xs_errors.XenError('SRNoSpace')]
@@ -232,12 +209,10 @@ class TestCBT(unittest.TestCase):
         with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, True)
 
-    @testlib.with_context
     @mock.patch('blktap2.VDI', autospec=True)
     @mock.patch('VDI.cbtutil', autospec=True)
-    def test_configure_blocktracking_enable_metadata_creation_fail(self, context, mock_cbt, mock_bt_vdi):
-        context.setup_error_codes()
-
+    def test_configure_blocktracking_enable_metadata_creation_fail(
+            self, mock_cbt, mock_bt_vdi):
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, False)
@@ -249,12 +224,10 @@ class TestCBT(unittest.TestCase):
         self._check_tapdisk_not_modified(mock_bt_vdi)
         self._check_setting_state(self.vdi, False)
 
-    @testlib.with_context
     @mock.patch('blktap2.VDI', autospec=True)
     @mock.patch('VDI.cbtutil', autospec=True)
-    def test_configure_blocktracking_enable_metadata_initialisation_fail(self, context, mock_cbt, mock_bt_vdi):
-        context.setup_error_codes()
-
+    def test_configure_blocktracking_enable_metadata_initialisation_fail(
+            self, mock_cbt, mock_bt_vdi):
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, False)
@@ -266,12 +239,10 @@ class TestCBT(unittest.TestCase):
         self._check_tapdisk_not_modified(mock_bt_vdi)
         self._check_setting_state(self.vdi, False)
 
-    @testlib.with_context
     @mock.patch('blktap2.VDI')
     @mock.patch('lock.LockImplementation')
-    def test_configure_blocktracking_disable_metadata_deletion_fail(self, context, mock_lock, mock_bt_vdi):
-        context.setup_error_codes()
-
+    def test_configure_blocktracking_disable_metadata_deletion_fail(
+            self, mock_lock, mock_bt_vdi):
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, True)
@@ -286,8 +257,6 @@ class TestCBT(unittest.TestCase):
     @testlib.with_context
     @mock.patch('VDI.cbtutil', autospec=True)
     def test_activate_no_tracking_success(self, context, mock_cbt):
-        context.setup_error_codes()
-
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, False)
@@ -303,8 +272,6 @@ class TestCBT(unittest.TestCase):
     @mock.patch('VDI.VDI._cbt_op', autospec=True)
     @mock.patch('lock.LockImplementation', autospec=True)
     def test_activate_consistent_success(self, context, mock_lock, mock_cbt):
-        context.setup_error_codes()
-
         expected_log_path = '/mock/sr_path/{0}.log'.format(self.vdi_uuid)
         logname = '%s.cbtlog' % self.vdi_uuid
 
@@ -330,8 +297,6 @@ class TestCBT(unittest.TestCase):
     @mock.patch('VDI.cbtutil', autospec=True)
     @mock.patch('lock.LockImplementation', autospec=True)
     def test_activate_consistency_check_fail(self, context, mock_lock, mock_cbt):
-        context.setup_error_codes()
-
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, True)
@@ -347,8 +312,6 @@ class TestCBT(unittest.TestCase):
     @testlib.with_context
     @mock.patch('VDI.cbtutil', autospec=True)
     def test_deactivate_no_tracking_success(self, context, mock_cbt):
-        context.setup_error_codes()
-
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, False)
@@ -364,8 +327,6 @@ class TestCBT(unittest.TestCase):
     @mock.patch('VDI.VDI._cbt_op', autospec=True)
     @mock.patch('lock.LockImplementation', autospec=True)
     def test_deactivate_success(self, context, mock_lock, mock_cbt):
-        context.setup_error_codes()
-
         expected_log_path = '/mock/sr_path/{0}.log'.format(self.vdi_uuid)
         logname = '%s.cbtlog' % self.vdi_uuid
 
@@ -381,8 +342,6 @@ class TestCBT(unittest.TestCase):
 
     @testlib.with_context
     def test_snapshot_success_with_CBT_disable(self, context):
-        context.setup_error_codes()
-
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, False)
@@ -402,8 +361,6 @@ class TestCBT(unittest.TestCase):
     @mock.patch('lock.LockImplementation')
     def test_snapshot_success_no_parent(self, context, mock_lock,
                                         mock_logchecker, mock_cbt):
-        context.setup_error_codes()
-
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, True)
@@ -437,15 +394,12 @@ class TestCBT(unittest.TestCase):
         self._check_CBT_chain_created(self.vdi, mock_cbt, self.vdi_uuid,
                                       snap_uuid, parent_uuid, child_uuid)
 
-    @testlib.with_context
     @mock.patch('VDI.VDI._cbt_op', autospec=True)
     @mock.patch('VDI.VDI._cbt_log_exists', autospec=True)
     @mock.patch('VDI.VDI._ensure_cbt_space', autospec=True)
     @mock.patch('util.SMlog', autospec=True)
-    def test_snapshot_out_of_space_failure(self, context, mock_smlog,
+    def test_snapshot_out_of_space_failure(self, mock_smlog,
             mock_ensure_space, mock_logcheck, mock_cbt):
-        context.setup_error_codes()
-
         # Create the test object
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         # Set initial state
@@ -594,11 +548,10 @@ class TestCBT(unittest.TestCase):
         mock_cbt.coalesce_bitmap.assert_called_with(logpath, child_log)
         self.vdi.state_mock._delete_cbt_log.assert_called_with()
 
-    @testlib.with_context
     @mock.patch('VDI.cbtutil', autospec=True)
     @mock.patch('VDI.VDI._cbt_log_exists')
     @mock.patch('lock.LockImplementation')
-    def test_vdi_delete_bitmap_coalesce_exc(self, context, mock_lock,
+    def test_vdi_delete_bitmap_coalesce_exc(self, mock_lock,
                                             mock_logcheck, mock_cbt):
         # Create the test object and initialise
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
@@ -618,9 +571,7 @@ class TestCBT(unittest.TestCase):
         mock_cbt.set_cbt_parent.assert_called_with(child_log, self.vdi_uuid)
         self.assertEqual(0, self.vdi.state_mock._delete_cbt_log.call_count)
 
-    @testlib.with_context
-    def test_list_changed_blocks_same_vdi(self, context):
-        context.setup_error_codes()
+    def test_list_changed_blocks_same_vdi(self):
         # Create the test object and initialise
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self.xenapi.VDI.get_uuid.return_value = self.vdi_uuid
@@ -630,10 +581,8 @@ class TestCBT(unittest.TestCase):
         # Test CBTChangedBlocksError is raised
         self.assertEqual(exc.exception.errno, 460)
 
-    @testlib.with_context
     @mock.patch('VDI.VDI._cbt_log_exists', autospec=True)
-    def test_list_changed_blocks_not_related(self, context, mock_log):
-        context.setup_error_codes()
+    def test_list_changed_blocks_not_related(self, mock_log):
         # Create the test object and initialise
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self.xenapi.VDI.get_uuid.return_value = "target_uuid"
@@ -645,9 +594,7 @@ class TestCBT(unittest.TestCase):
         # Test CBTChangedBlocksError is raised
         self.assertEqual(exc.exception.errno, 460)
 
-    @testlib.with_context
-    def test_list_changed_blocks_cbt_disabled(self, context):
-        context.setup_error_codes()
+    def test_list_changed_blocks_cbt_disabled(self):
         # Create the test object and initialise
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, False)
@@ -664,7 +611,6 @@ class TestCBT(unittest.TestCase):
     @mock.patch('lock.LockImplementation', autospec=True)
     def test_list_changed_blocks_success(self, context, mock_lock,
                                          mock_log, mock_cbt):
-        context.setup_error_codes()
         # Create the test object and initialise
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, True)
@@ -696,7 +642,6 @@ class TestCBT(unittest.TestCase):
     def test_list_changed_blocks_vdi_resized_success(self, context,
                                                      mock_lock, mock_log,
                                                      mock_cbt):
-        context.setup_error_codes()
         # Create the test object and initialise
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, True)
@@ -723,13 +668,11 @@ class TestCBT(unittest.TestCase):
         result = self.vdi.list_changed_blocks()
         self.assertEqual(result, expected_result)
 
-    @testlib.with_context
     @mock.patch('VDI.cbtutil', autospec=True)
     @mock.patch('VDI.VDI._cbt_log_exists', autospec=True)
     @mock.patch('lock.LockImplementation', autospec=True)
-    def test_list_changed_blocks_vdi_shrunk(self, context, mock_lock,
+    def test_list_changed_blocks_vdi_shrunk(self, mock_lock,
                                             mock_log, mock_cbt):
-        context.setup_error_codes()
         # Create the test object and initialise
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, True)
@@ -748,14 +691,12 @@ class TestCBT(unittest.TestCase):
         # Test CBTChangedBlocksError is raised
         self.assertEqual(exc.exception.errno, 459)
 
-    @testlib.with_context
     @mock.patch('VDI.cbtutil', autospec=True)
     @mock.patch('VDI.VDI._cbt_log_exists', autospec=True)
     @mock.patch('lock.LockImplementation', autospec=True)
-    def test_list_changed_blocks_smaller_bitmap(self, context,
+    def test_list_changed_blocks_smaller_bitmap(self,
                                                 mock_lock,
                                                 mock_log, mock_cbt):
-        context.setup_error_codes()
         # Create the test object and initialise
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, True)
@@ -779,7 +720,6 @@ class TestCBT(unittest.TestCase):
     def test_list_changed_blocks_larger_bitmap(self, context,
                                                mock_lock,
                                                mock_log, mock_cbt):
-        context.setup_error_codes()
         # Create the test object and initialise
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, True)
@@ -815,7 +755,6 @@ class TestCBT(unittest.TestCase):
     def test_list_changed_blocks_strip_sensitive_bitmap(self, context, mock_lock,
                                                         mock_log, mock_call,
                                                         mock_child, mock_size):
-        context.setup_error_codes()
         # Create the test object and initialise
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self._set_initial_state(self.vdi, True)

--- a/tests/test_cbt.py
+++ b/tests/test_cbt.py
@@ -173,7 +173,7 @@ class TestCBT(unittest.TestCase):
         self.vdi = VDI.VDI(self.sr, self.vdi_uuid)
         self.vdi.path = "/mock/sr_path/" + str(self.vdi_uuid)
 
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, True)
 
     @testlib.with_context
@@ -184,7 +184,7 @@ class TestCBT(unittest.TestCase):
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self.xenapi.VDI.get_is_a_snapshot.return_value = True
 
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, True)
 
     @testlib.with_context
@@ -200,7 +200,7 @@ class TestCBT(unittest.TestCase):
         self._set_initial_state(self.vdi, False)
         mock_bt_vdi.tap_pause.return_value = False
 
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, True)
 
     @testlib.with_context
@@ -215,7 +215,7 @@ class TestCBT(unittest.TestCase):
         self._set_initial_state(self.vdi, True)
         mock_bt_vdi.tap_pause.return_value = False
 
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, False)
 
     @testlib.with_context
@@ -229,7 +229,7 @@ class TestCBT(unittest.TestCase):
 
         self._set_initial_state(self.vdi, False)
 
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, True)
 
     @testlib.with_context
@@ -243,7 +243,7 @@ class TestCBT(unittest.TestCase):
         self._set_initial_state(self.vdi, False)
         self.vdi.state_mock._get_cbt_logpath.side_effect = [xs_errors.XenError('CBTActivateFailed')]
 
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, True)
 
         self._check_tapdisk_not_modified(mock_bt_vdi)
@@ -260,7 +260,7 @@ class TestCBT(unittest.TestCase):
         self._set_initial_state(self.vdi, False)
         mock_cbt.create_cbt_log.side_effect = Exception(errno.EIO)
 
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, True)
 
         self._check_tapdisk_not_modified(mock_bt_vdi)
@@ -277,7 +277,7 @@ class TestCBT(unittest.TestCase):
         self._set_initial_state(self.vdi, True)
         self.vdi.state_mock._delete_cbt_log.side_effect = [xs_errors.XenError('CBTDeactivateFailed')]
 
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             self.vdi.configure_blocktracking(self.sr_uuid, self.vdi_uuid, False)
 
         #self._check_tapdisk_not_modified(mock_bt_vdi)
@@ -625,7 +625,7 @@ class TestCBT(unittest.TestCase):
         self.vdi = TestVDI(self.sr, self.vdi_uuid)
         self.xenapi.VDI.get_uuid.return_value = self.vdi_uuid
 
-        with self.assertRaises(SR.SROSError) as exc:
+        with self.assertRaises(xs_errors.SROSError) as exc:
             self.vdi.list_changed_blocks()
         # Test CBTChangedBlocksError is raised
         self.assertEqual(exc.exception.errno, 460)
@@ -640,7 +640,7 @@ class TestCBT(unittest.TestCase):
         # Terminate the chain before target_uuid is reached
         mock_log.side_effect = [True, False]
 
-        with self.assertRaises(SR.SROSError) as exc:
+        with self.assertRaises(xs_errors.SROSError) as exc:
             self.vdi.list_changed_blocks()
         # Test CBTChangedBlocksError is raised
         self.assertEqual(exc.exception.errno, 460)
@@ -653,7 +653,7 @@ class TestCBT(unittest.TestCase):
         self._set_initial_state(self.vdi, False)
         self.xenapi.VDI.get_uuid.return_value = "target_uuid"
 
-        with self.assertRaises(SR.SROSError) as exc:
+        with self.assertRaises(xs_errors.SROSError) as exc:
             self.vdi.list_changed_blocks()
         # Test CBTChangedBlocksError is raised
         self.assertEqual(exc.exception.errno, 460)
@@ -743,7 +743,7 @@ class TestCBT(unittest.TestCase):
         mock_cbt.get_cbt_bitmap.side_effect = [bitmap1.tobytes(),
                                                bitmap2.tobytes()]
 
-        with self.assertRaises(SR.SROSError) as exc:
+        with self.assertRaises(xs_errors.SROSError) as exc:
             self.vdi.list_changed_blocks()
         # Test CBTChangedBlocksError is raised
         self.assertEqual(exc.exception.errno, 459)
@@ -767,7 +767,7 @@ class TestCBT(unittest.TestCase):
                                                bitmap2.tobytes()]
         mock_cbt.get_cbt_size.return_value = 16777216
 
-        with self.assertRaises(SR.SROSError) as exc:
+        with self.assertRaises(xs_errors.SROSError) as exc:
             self.vdi.list_changed_blocks()
         # Test CBTChangedBlocksError is raised
         self.assertEqual(exc.exception.errno, 459)

--- a/tests/test_mpath_dmp.py
+++ b/tests/test_mpath_dmp.py
@@ -34,17 +34,12 @@ class TestMpathDmp(unittest.TestCase):
 
         self.addCleanup(mock.patch.stopall)
 
-    @testlib.with_context
     @mock.patch('mpath_dmp.util', autospec=True)
     @mock.patch('mpath_dmp.os', autospec=True)
-    def test_is_valid_multipath_device(self, context, mock_os, util_mod):
+    def test_is_valid_multipath_device(self, mock_os, util_mod):
         """
         Tests for checking validity of multipath device
         """
-
-        # Setup errors codes
-        context.setup_error_codes()
-
         # Test 'multipath -ll' success
         util_mod.doexec.side_effect = [(0, "out", "err")]
         self.assertTrue(mpath_dmp._is_valid_multipath_device("fake_dev"))
@@ -145,16 +140,12 @@ class TestMpathDmp(unittest.TestCase):
             msg='wait_for_path not called with expected mapper path')
         mock_activate.assert_called_with(test_id, mock.ANY)
 
-    @testlib.with_context
     @mock.patch('mpath_dmp._is_valid_multipath_device', autospec=True)
     @mock.patch('mpath_dmp.util', autospec=True)
-    def test_refresh_dmp_device_not_found(self, context, mock_util, mock_valid):
+    def test_refresh_dmp_device_not_found(self, mock_util, mock_valid):
         """
         Test refresh DMP device not found
         """
-        # Setup error codes
-        context.setup_error_codes()
-
         mock_valid.return_value = True
 
         test_id = '360871234'
@@ -231,17 +222,13 @@ class TestMpathDmp(unittest.TestCase):
         mock_util.pread2.assert_called_once_with(
             ['/usr/bin/systemctl', 'start', 'multipathd.service'])
 
-    @testlib.with_context
     @mock.patch('mpath_dmp.iscsilib', autospec=True)
     @mock.patch('mpath_dmp.util', autospec=True)
     def test_activate_noiscsi_mpath_not_working(
-            self, context, mock_util, mock_iscsilib):
+            self, mock_util, mock_iscsilib):
         """
         MPATH activate, mpath not running
         """
-        # Setup error codes
-        context.setup_error_codes()
-
         mock_iscsilib.is_iscsi_daemon_running.return_value = False
         mock_util.doexec.return_value = (0, "", "")
         self.mock_mpath_cli.is_working.side_effect = [False] * 120
@@ -368,11 +355,7 @@ class TestMpathDmp(unittest.TestCase):
 
         self.assertEqual(1, mock_iscsilib.restart_daemon.call_count)
 
-    @testlib.with_context
-    def test_refresh_no_sid(self, context):
-        # Setup error codes
-        context.setup_error_codes()
-
+    def test_refresh_no_sid(self):
         with self.assertRaises(SROSError):
             mpath_dmp.refresh("", 0)
 
@@ -408,16 +391,11 @@ class TestMpathDmp(unittest.TestCase):
         mock_exists.assert_called_once_with(
             '/dev/disk/by-id/scsi-360a98000534b4f4e46704f5270674d70')
 
-    @testlib.with_context
     @mock.patch('mpath_dmp.util.wait_for_path', autospec=True)
     @mock.patch('mpath_dmp.scsiutil', autospec=True)
     @mock.patch('mpath_dmp.os.path.exists', autospec=True)
     def test_refresh_refresh_error(
-            self, context, mock_exists, mock_scsiutil, mock_wait):
-
-        # Setup error codes
-        context.setup_error_codes()
-
+            self, mock_exists, mock_scsiutil, mock_wait):
         def exists(path):
             print('Exists %s' % path)
             if path.startswith('/dev/'):

--- a/tests/test_mpath_dmp.py
+++ b/tests/test_mpath_dmp.py
@@ -9,8 +9,7 @@ import testlib
 import util
 
 import mpath_dmp
-import SR
-from SR import SROSError
+from xs_errors import SROSError
 
 from queue import Queue
 
@@ -64,7 +63,7 @@ class TestMpathDmp(unittest.TestCase):
         mock_os.listdir.side_effect = [['sdc']]
         util_mod.doexec.side_effect = [(0, "", ""), (0, "", ""), (0, "out", "err"),
                                        (1, "", ""), OSError()]
-        with self.assertRaises(SR.SROSError) as exc:
+        with self.assertRaises(SROSError) as exc:
             mpath_dmp._is_valid_multipath_device("xx")
         self.assertEqual(exc.exception.errno, 431)
 
@@ -374,7 +373,7 @@ class TestMpathDmp(unittest.TestCase):
         # Setup error codes
         context.setup_error_codes()
 
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(SROSError):
             mpath_dmp.refresh("", 0)
 
     @mock.patch('mpath_dmp._refresh_DMP', autospec=True)
@@ -429,5 +428,5 @@ class TestMpathDmp(unittest.TestCase):
         mock_exists.side_effect = exists
         mock_wait.return_value = False
 
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(SROSError):
             mpath_dmp.refresh('360a98000534b4f4e46704f5270674d70', 0)

--- a/tests/test_srmetadata.py
+++ b/tests/test_srmetadata.py
@@ -451,7 +451,6 @@ class LVMMetadataTestContext(testlib.TestContext):
 
     def __init__(self):
         super().__init__()
-        self.setup_error_codes()
         self._metadata_file_content = b'\x00' * 4 * 1024 * 1024
 
     def start(self):
@@ -459,8 +458,6 @@ class LVMMetadataTestContext(testlib.TestContext):
         self.patch("util.gen_uuid", new=genuuid)
 
     def generate_device_paths(self):
-        for path in super().generate_device_paths():
-            yield path
         yield self.METADATA_PATH
 
     def fake_open(self, fname, mode='r'):

--- a/tests/test_testlib.py
+++ b/tests/test_testlib.py
@@ -148,15 +148,6 @@ class TestTestContext(unittest.TestCase):
         os.stat('/existingstuff')
 
     @testlib.with_context
-    def test_error_codes_read(self, context):
-        context.setup_error_codes()
-        errorcodes_file = open('/opt/xensource/sm/XE_SR_ERRORCODES.xml', 'rb')
-        errorcodes = errorcodes_file.read()
-        errorcodes_file.close()
-
-        self.assertTrue("<SM-errorcodes>" in errorcodes.decode())
-
-    @testlib.with_context
     def test_executable_shows_up_on_filesystem(self, context):
         context.add_executable('/something', None)
 
@@ -217,13 +208,6 @@ class TestTestContext(unittest.TestCase):
         os.makedirs('/blah/subdir')
 
         self.assertRaises(OSError, os.makedirs, '/blah/subdir')
-
-    @testlib.with_context
-    def test_setup_error_codes(self, context):
-        context.setup_error_codes()
-
-        self.assertTrue(
-            os.path.exists('/opt/xensource/sm/XE_SR_ERRORCODES.xml'))
 
     @testlib.with_context
     def test_write_a_file(self, context):
@@ -362,18 +346,6 @@ class TestTestContext(unittest.TestCase):
         with self.assertRaises(OSError) as cm:
             context.fake_rmdir('/existing_dir')
         self.assertEqual(errno.ENOTEMPTY, cm.exception.errno)
-
-    def test_get_error_code(self):
-        context = testlib.TestContext()
-        self.assertEqual(context.get_error_code("SMBMount"), 111)
-
-    def test_get_error_code_not_found(self):
-        """
-        When error code can't be found then None is returned.
-        This test is to keep 100% coverage on tests.
-        """
-        context = testlib.TestContext()
-        self.assertEqual(context.get_error_code("PANCAKES"), None)
 
 
 class TestFilesystemFor(unittest.TestCase):

--- a/tests/test_trim_util.py
+++ b/tests/test_trim_util.py
@@ -35,7 +35,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
                                                    context,
                                                    sr_get_capability):
         sr_get_capability.return_value = []
-        context.setup_error_codes()
 
         result = trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})
 
@@ -64,7 +63,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
                                                  sleep):
         MockLock.return_value = AlwaysBusyLock()
         sr_get_capability.return_value = [trim_util.TRIM_CAP]
-        context.setup_error_codes()
 
         result = trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})
 
@@ -93,7 +91,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
                                                           sleep):
         MockLock.return_value = AlwaysBusyLock()
         sr_get_capability.return_value = [trim_util.TRIM_CAP]
-        context.setup_error_codes()
 
         trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})
 
@@ -120,7 +117,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
                                            'freespace': EMPTY_VG_SPACE}
         MockLock.return_value = AlwaysFreeLock()
         sr_get_capability.return_value = [trim_util.TRIM_CAP]
-        context.setup_error_codes()
 
         trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})
 
@@ -147,7 +143,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
         lvutil.exists.return_value = False
         MockLock.return_value = AlwaysFreeLock()
         sr_get_capability.return_value = [trim_util.TRIM_CAP]
-        context.setup_error_codes()
 
         trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})
 
@@ -167,7 +162,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
         lvutil.exists.return_value = False
         sr_lock = MockLock.return_value = AlwaysFreeLock()
         sr_get_capability.return_value = [trim_util.TRIM_CAP]
-        context.setup_error_codes()
 
         trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})
 
@@ -185,7 +179,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
         lvutil.exists.return_value = True
         MockLock.return_value = AlwaysFreeLock()
         sr_get_capability.return_value = [trim_util.TRIM_CAP]
-        context.setup_error_codes()
 
         trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})
 
@@ -208,7 +201,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
         srlock = AlwaysFreeLock()
         MockLock.return_value = srlock
         sr_get_capability.return_value = [trim_util.TRIM_CAP]
-        context.setup_error_codes()
 
         trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})
 
@@ -231,7 +223,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
         srlock = AlwaysFreeLock()
         MockLock.return_value = srlock
         sr_get_capability.return_value = [trim_util.TRIM_CAP]
-        context.setup_error_codes()
 
         result = trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})
 
@@ -266,7 +257,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
                                            'freespace': EMPTY_VG_SPACE}
         MockLock.return_value = AlwaysFreeLock()
         sr_get_capability.return_value = [trim_util.TRIM_CAP]
-        context.setup_error_codes()
 
         result = trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})
 
@@ -328,7 +318,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
                                            'freespace': 0}
         MockLock.return_value = AlwaysFreeLock()
         sr_get_capability.return_value = [trim_util.TRIM_CAP]
-        context.setup_error_codes()
 
         result = trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})
 
@@ -366,7 +355,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
                                            'freespace': EMPTY_VG_SPACE}
         mock_lock.return_value = AlwaysFreeLock()
         sr_get_capability.return_value = [trim_util.TRIM_CAP]
-        context.setup_error_codes()
 
         # Act
         result = trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})
@@ -394,7 +382,6 @@ class TestTrimUtil(unittest.TestCase, testlib.XmlMixIn):
                                            'freespace': EMPTY_VG_SPACE}
         mock_lock.return_value = AlwaysFreeLock()
         sr_get_capability.return_value = [trim_util.TRIM_CAP]
-        context.setup_error_codes()
 
         # Act
         result = trim_util.do_trim(None, {'sr_uuid': 'some-uuid'})

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,8 +8,8 @@ import unittest.mock as mock
 import uuid
 import xmlrpc.client
 
-import SR
 import util
+import xs_errors
 
 DD_CMD = "/bin/dd"
 
@@ -584,7 +584,7 @@ class TestUtil(unittest.TestCase):
         self.mock_socket.getaddrinfo.side_effect = socket.gaierror(errno.ENOENT)
 
         # Act
-        with self.assertRaises(SR.SROSError) as sroe:
+        with self.assertRaises(xs_errors.SROSError) as sroe:
             util._testHost("test-server", 3260, "ISCSITarget")
 
         self.assertEqual(140, sroe.exception.errno)
@@ -599,7 +599,7 @@ class TestUtil(unittest.TestCase):
         open_socket.connect.side_effect = socket.error("Timed out")
 
         # Act
-        with self.assertRaises(SR.SROSError) as sroe:
+        with self.assertRaises(xs_errors.SROSError) as sroe:
             util._testHost("test-server", 3260, "ISCSITarget")
 
         # Assert

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -578,7 +578,6 @@ class TestUtil(unittest.TestCase):
         open_socket.connect.assert_called_with(("192.168.1.2", 3260))
         open_socket.send.assert_called_once_with(b"\n")
 
-    @mock.patch('SR.xs_errors.XML_DEFS', "drivers/XE_SR_ERRORCODES.xml")
     def test_host_dns_lookup_failure(self):
         # Arrange
         self.mock_socket.getaddrinfo.side_effect = socket.gaierror(errno.ENOENT)
@@ -589,7 +588,6 @@ class TestUtil(unittest.TestCase):
 
         self.assertEqual(140, sroe.exception.errno)
 
-    @mock.patch('SR.xs_errors.XML_DEFS', "drivers/XE_SR_ERRORCODES.xml")
     def test_host_connect_failure(self):
         # Arrange
         sock_addr = (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP,

--- a/tests/test_vhdutil.py
+++ b/tests/test_vhdutil.py
@@ -3,8 +3,8 @@ import unittest
 import zlib
 
 import lvhdutil
-import SR
 import vhdutil
+import xs_errors
 
 import testlib
 
@@ -35,13 +35,13 @@ class TestVhdUtil(unittest.TestCase):
     @testlib.with_context
     def test_validate_and_round_negative(self, context):
         context.setup_error_codes()
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             vhdutil.validate_and_round_vhd_size(-1)
 
     @testlib.with_context
     def test_validate_and_round_too_large(self, context):
         context.setup_error_codes()
-        with self.assertRaises(SR.SROSError):
+        with self.assertRaises(xs_errors.SROSError):
             vhdutil.validate_and_round_vhd_size(vhdutil.MAX_VHD_SIZE + 1)
 
     @testlib.with_context

--- a/tests/test_vhdutil.py
+++ b/tests/test_vhdutil.py
@@ -32,15 +32,11 @@ class TestVhdUtil(unittest.TestCase):
 
         self.assertTrue(size == vhdutil.MAX_VHD_SIZE)
 
-    @testlib.with_context
-    def test_validate_and_round_negative(self, context):
-        context.setup_error_codes()
+    def test_validate_and_round_negative(self):
         with self.assertRaises(xs_errors.SROSError):
             vhdutil.validate_and_round_vhd_size(-1)
 
-    @testlib.with_context
-    def test_validate_and_round_too_large(self, context):
-        context.setup_error_codes()
+    def test_validate_and_round_too_large(self):
         with self.assertRaises(xs_errors.SROSError):
             vhdutil.validate_and_round_vhd_size(vhdutil.MAX_VHD_SIZE + 1)
 

--- a/tests/test_xs_errors.py
+++ b/tests/test_xs_errors.py
@@ -1,22 +1,20 @@
 import unittest
-
-import testlib
+from unittest import mock
 
 import xs_errors
 
 
 class TestXenError(unittest.TestCase):
-    @testlib.with_context
-    def test_without_xml_defs(self, context):
+    @mock.patch('xs_errors.os.path.exists', autospec=True)
+    def test_without_xml_defs(self, mock_exists):
+        mock_exists.return_value = False
+
         with self.assertRaises(Exception) as e:
             xs_errors.XenError('blah')
 
         self.assertTrue("No XML def file found" in str(e.exception))
 
-    @testlib.with_context
-    def test_xml_defs(self, context):
-        context.setup_error_codes()
-
+    def test_xml_defs(self):
         with self.assertRaises(Exception) as e:
             raise xs_errors.XenError('SRInUse')
 

--- a/tests/testlib.py
+++ b/tests/testlib.py
@@ -17,16 +17,6 @@ class ContextSetupError(Exception):
     pass
 
 
-def get_error_codes():
-    this_dir = os.path.dirname(__file__)
-    drivers_dir = os.path.join(this_dir, '..', 'drivers')
-    error_codes_path = os.path.join(drivers_dir, 'XE_SR_ERRORCODES.xml')
-    error_code_catalog = open(error_codes_path, 'r')
-    contents = error_code_catalog.read()
-    error_code_catalog.close()
-    return contents.encode('utf-8')
-
-
 class SCSIDisk(object):
     def __init__(self, adapter):
         self.adapter = adapter
@@ -93,7 +83,6 @@ class Subprocess(object):
 class TestContext(object):
     def __init__(self):
         self.patchers = []
-        self.error_codes = get_error_codes()
         self.inventory = {
             'PRIMARY_DISK': '/dev/disk/by-id/primary'
         }
@@ -168,11 +157,6 @@ class TestContext(object):
 
     def setup_modinfo(self):
         self.add_executable('/sbin/modinfo', self.fake_modinfo)
-
-    def setup_error_codes(self):
-        self._path_content['/opt/xensource/sm/XE_SR_ERRORCODES.xml'] = (
-            self.error_codes
-        )
 
     def fake_modinfo(self, args, stdin_data):
         assert len(args) == 3
@@ -329,14 +313,6 @@ class TestContext(object):
     def add_adapter(self, adapter):
         self.scsi_adapters.append(adapter)
         return adapter
-
-    def get_error_code(self, error_name):
-        xml = parseString(self.error_codes)
-        for code in xml.getElementsByTagName('code'):
-            name = code.getElementsByTagName('name')[0].firstChild.nodeValue
-            if name == error_name:
-                return int(code.getElementsByTagName('value')[0].firstChild.nodeValue)
-        return None
 
     @staticmethod
     def is_binary(mode):


### PR DESCRIPTION
xs_errors is one of the lowest level modules in the SM codebase yet it
imports the SR module, in order to access the SROSError class, which
is one of the highest level modules. The SR subclasses then import the
xs_errors module.

Correct this inverted dependency chain by moving the declaration of
the error class into xs_errors and fix up the usage.

Also load the XML error message declarations from a sibling file to 
simplify the unit tests and remove a hard coded path, which might
in the future change.