### PR TITLE
CP-49720 Move LOCK_TYPE_RUNNING from cleanup.py to lock.py

### DIFF
--- a/drivers/FileSR.py
+++ b/drivers/FileSR.py
@@ -31,7 +31,7 @@ import blktap2
 import time
 import glob
 from uuid import uuid4
-from lock import Lock
+from lock import Lock, LOCK_TYPE_GC_RUNNING
 import xmlrpc.client
 import XenAPI # pylint: disable=import-error
 from constants import CBTLOG_TAG
@@ -381,7 +381,7 @@ class FileSR(SR.SR):
         # don't bother if an instance already running (this is just an
         # optimization to reduce the overhead of forking a new process if we
         # don't have to, but the process will check the lock anyways)
-        lockRunning = Lock(cleanup.LOCK_TYPE_RUNNING, self.uuid)
+        lockRunning = Lock(LOCK_TYPE_GC_RUNNING, self.uuid)
         if not lockRunning.acquireNoblock():
             if cleanup.should_preempt(self.session, self.uuid):
                 util.SMlog("Aborting currently-running coalesce of garbage VDI")

--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -36,7 +36,7 @@ import xs_errors
 import cleanup
 import blktap2
 from journaler import Journaler
-from lock import Lock
+from lock import Lock, LOCK_TYPE_GC_RUNNING
 from refcounter import RefCounter
 from ipc import IPCFlag
 from lvmanager import LVActivator
@@ -1292,7 +1292,7 @@ class LVHDSR(SR.SR):
         # don't bother if an instance already running (this is just an
         # optimization to reduce the overhead of forking a new process if we
         # don't have to, but the process will check the lock anyways)
-        lockRunning = Lock(cleanup.LOCK_TYPE_RUNNING, self.uuid)
+        lockRunning = Lock(LOCK_TYPE_GC_RUNNING, self.uuid)
         if not lockRunning.acquireNoblock():
             if cleanup.should_preempt(self.session, self.uuid):
                 util.SMlog("Aborting currently-running coalesce of garbage VDI")

--- a/drivers/iscsilib.py
+++ b/drivers/iscsilib.py
@@ -26,7 +26,6 @@ import xs_errors
 import lock
 import glob
 import tempfile
-from cleanup import LOCK_TYPE_RUNNING
 from configparser import RawConfigParser
 import io
 
@@ -54,7 +53,7 @@ def doexec_locked(cmd):
     """Executes via util.doexec the command specified whilst holding lock"""
     _lock = None
     if os.path.basename(cmd[0]) == 'iscsiadm':
-        _lock = lock.Lock(LOCK_TYPE_RUNNING, 'iscsiadm')
+        _lock = lock.Lock(lock.LOCK_TYPE_GC_RUNNING, 'iscsiadm')
         _lock.acquire()
     # util.SMlog("%s" % cmd)
     (rc, stdout, stderr) = util.doexec(cmd)

--- a/drivers/iscsilib.py
+++ b/drivers/iscsilib.py
@@ -53,7 +53,7 @@ def doexec_locked(cmd):
     """Executes via util.doexec the command specified whilst holding lock"""
     _lock = None
     if os.path.basename(cmd[0]) == 'iscsiadm':
-        _lock = lock.Lock(lock.LOCK_TYPE_GC_RUNNING, 'iscsiadm')
+        _lock = lock.Lock(lock.LOCK_TYPE_ISCSIADM_RUNNING, 'iscsiadm')
         _lock.acquire()
     # util.SMlog("%s" % cmd)
     (rc, stdout, stderr) = util.doexec(cmd)

--- a/drivers/lock.py
+++ b/drivers/lock.py
@@ -23,6 +23,8 @@ import util
 
 VERBOSE = True
 
+# Still just called "running" for backwards compatibility
+LOCK_TYPE_GC_RUNNING = "running"
 
 class LockException(util.SMException):
     pass

--- a/drivers/lock.py
+++ b/drivers/lock.py
@@ -25,6 +25,7 @@ VERBOSE = True
 
 # Still just called "running" for backwards compatibility
 LOCK_TYPE_GC_RUNNING = "running"
+LOCK_TYPE_ISCSIADM_RUNNING = "isciadm_running"
 
 class LockException(util.SMException):
     pass

--- a/drivers/resetvdis.py
+++ b/drivers/resetvdis.py
@@ -26,11 +26,10 @@ import XenAPI # pylint: disable=import-error
 
 def reset_sr(session, host_uuid, sr_uuid, is_sr_master):
     from vhdutil import LOCK_TYPE_SR
-    from cleanup import LOCK_TYPE_RUNNING
 
     cleanup.abort(sr_uuid)
 
-    gc_lock = lock.Lock(LOCK_TYPE_RUNNING, sr_uuid)
+    gc_lock = lock.Lock(lock.LOCK_TYPE_GC_RUNNING, sr_uuid)
     sr_lock = lock.Lock(LOCK_TYPE_SR, sr_uuid)
     gc_lock.acquire()
     sr_lock.acquire()

--- a/tests/test_FileSR.py
+++ b/tests/test_FileSR.py
@@ -450,6 +450,9 @@ class TestShareFileSR(unittest.TestCase):
         lock_patcher = mock.patch('FileSR.Lock')
         self.mock_lock = lock_patcher.start()
 
+        lock_patcher_cleanup = mock.patch('cleanup.lock.Lock')
+        self.mock_lock_cleanup = lock_patcher_cleanup.start()
+
         xapi_patcher = mock.patch('SR.XenAPI')
         self.mock_xapi = xapi_patcher.start()
         self.mock_session = mock.MagicMock()


### PR DESCRIPTION
In the process, rename LOCK_TYPE_RUNNING to LOCK_TYPE_GC_RUNNING to describe *what* is running when it's running. This matches LOCK_TYPE_GC_ACTIVE which remains in cleanup.py because it is only used there.

Rename the global variables in cleanup.py to describe *what* is Active/Running.