### PR TITLE
CP-49775 convert SMGC to systemd service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,8 @@ install: precheck
 	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
 	install -m 644 systemd/sr_health_check.timer \
 	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
+	install -m 644 systemd/SMGC@.service \
+	  $(SM_STAGING)/$(SYSTEMD_SERVICE_DIR)
 	for i in $(UDEV_RULES); do \
 	  install -m 644 udev/$$i.rules \
 	    $(SM_STAGING)$(UDEV_RULES_DIR); done

--- a/drivers/FileSR.py
+++ b/drivers/FileSR.py
@@ -379,7 +379,7 @@ class FileSR(SR.SR):
 
     def _kickGC(self):
         util.SMlog("Kicking GC")
-        cleanup.start_gc(self.session, self.uuid)
+        cleanup.start_gc_service(self.uuid)
 
     def _isbind(self):
         # os.path.ismount can't deal with bind mount

--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -1290,7 +1290,7 @@ class LVHDSR(SR.SR):
 
     def _kickGC(self):
         util.SMlog("Kicking GC")
-        cleanup.start_gc(self.session, self.uuid)
+        cleanup.start_gc_service(self.uuid)
 
     def ensureCBTSpace(self):
         # Ensure we have space for at least one LV

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -212,6 +212,7 @@ tests/run_python_unittests.sh
 %{_unitdir}/usb-scan.socket
 %{_unitdir}/mpathcount.service
 %{_unitdir}/mpathcount.socket
+%{_unitdir}/SMGC@.service
 %config /etc/udev/rules.d/65-multipath.rules
 %config /etc/udev/rules.d/55-xs-mpath-scsidev.rules
 %config /etc/udev/rules.d/58-xapi.rules

--- a/systemd/SMGC@.service
+++ b/systemd/SMGC@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Garbage Collector for SR %I
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+Restart=no
+ExecStart=/opt/xensource/sm/cleanup.py -g -u %I
+# This is the default, but just to make it clear we may run this
+# service multiple times. When running, it will show as "activating";
+# when not running, it will show as "dead"
+RemainAfterExit=no


### PR DESCRIPTION
Add a templated oneshot service and use systemctl to start it. The systemctl command is invoked with "--no-wait" so that it returns immediately because the "oneshot" nature of the service would otherwise wait until the command completes.

Note that because the service is a oneshot with RemainAfterExit=no (so we can multiply start it), it will go from "activating" to "dead" without ever appearing to be "running".