### PR TITLE
Add logging to fairlock

### DIFF
--- a/misc/fairlock/fairlock.py
+++ b/misc/fairlock/fairlock.py
@@ -57,6 +57,8 @@ class Fairlock(metaclass=SingletonWithArgs):
         except (FileNotFoundError, ConnectionRefusedError):
             self._ensure_service()
             self.sock.connect(self.sockname)
+
+        self.sock.send(f'{os.getpid()} - {time.monotonic()}'.encode())
         self.connected = True
         return self
 


### PR DESCRIPTION
Log to LOCAL2 at log level INFO when a lock is acquired and released, and when the client holding the lock sends anything through the socket (they can use this to identify themselves to the logging e.g. by sending "PID <PID>"

Extended from Tim's original change to actually pass PID and (monotonic) time from the client.