### PR TITLE
feat: add HPE Nimble multipath configuration

### DIFF
--- a/multipath/multipath.conf
+++ b/multipath/multipath.conf
@@ -155,4 +155,19 @@ devices {
         prio                        alua
         failback                    immediate
     }
+    device {
+        vendor                      "Nimble"
+        product                     "Server"
+        path_grouping_policy        group_by_prio
+        prio                        "alua"
+        hardware_handler            "1 alua"
+        path_selector               "service-time 0"
+        path_checker                tur
+        no_path_retry               30
+        failback                    immediate
+        fast_io_fail_tmo            5
+        dev_loss_tmo                infinity
+        rr_min_io_rq                1
+        rr_weight                   uniform
+    }
 }


### PR DESCRIPTION
Hello All,

i used the HPE Storage Toolkit for Linux instructions to create this configuration.
We are actively using this config right now with our HPE Nimble AF-40 and 5 xcp-ng hosts.

https://infosight.hpe.com/InfoSight/media/cms/active/public/pubs_Linux_Integration_Guide_4_0_2.pdf

