### PR TITLE
CA-395554 Improve fairlocking reliability

### DIFF
--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -237,5 +237,14 @@ Manager and some other packages
 %{_unitdir}/fairlock@.service
 %{_libexecdir}/fairlock
 
+%posttrans fairlock
+## On upgrade, shut down existing lock services so new ones will
+## be started. There should be no locks held during upgrade operations
+## so this is safe.
+if [ $1 -gt 1 ];
+then
+    systemctl stop $(systemctl list-units fairlock@* --all --no-legend | cut -d' ' -f1)
+fi
+
 %changelog
 


### PR DESCRIPTION
Under some circumstances (when the listen queue is short enough) a process's blocking connect() to a UNIX-domain stream socket can return success even when the server side has not yet called accept().

To work around this, we have the server portion write a small fixed blob of data to each new connection and require the client to read it before it considers itself to have the lock; merely being connected successfully is no longer sufficient.