### PR TITLE
CA-395560 Log exception details when LUN refresh fails

### DIFF
--- a/drivers/scsiutil.py
+++ b/drivers/scsiutil.py
@@ -27,6 +27,7 @@ import time
 import errno
 import glob
 import mpath_cli
+import traceback
 
 PREFIX_LEN = 4
 SUFFIX_LEN = 12
@@ -601,8 +602,7 @@ def refresh_lun_size_by_SCSIid(SCSIid):
                        "find any devices for the SCSIid." % SCSIid)
         return True
     except:
-        util.logException("Error in scsiutil.refresh_lun_size_by_SCSIid(%s)"
-                          % SCSIid)
+        util.logException(f"Error in scsiutil.refresh_lun_size_by_SCSIid({SCSIid}: {traceback.format_exc()})")
         return False
 
 


### PR DESCRIPTION
In case there is an issue during refresh_lun_size_by_SCSIid() which causes it to return False, log what the issue actually is so that some attempt can be made to address it. If retries need to be added, we need to know *what* needs to be retried.