### PR TITLE
CA-398958 Cope with concurrent read-only activations

### DIFF
--- a/mocks/XenAPI/__init__.py
+++ b/mocks/XenAPI/__init__.py
@@ -1,6 +1,6 @@
 class Failure(Exception):
     def __init__(self, details):
-        pass
+        self.details = details
 
 def xapi_local():
     # Mock stub


### PR DESCRIPTION
It should be possible to activate a VDI on two different hosts in a pool simultaneously, provided read-only access is all that it required. So, if one host tries to activate in a brief window when another host has put the transient "activating" key on the VDI, it should be allowed to retry.