### PR TITLE
Add checks for Xapi enablement

### DIFF
--- a/drivers/mpathcount.py
+++ b/drivers/mpathcount.py
@@ -199,6 +199,14 @@ def check_devconfig(devconfig, sm_config, config, remove, add, mpath_status=None
             else:
                 update_config(key, i, config[key], remove, add, mpath_status)
 
+
+def check_xapi_is_enabled(session, hostref):
+    host = session.xenapi.host.get_record(hostref)
+    if not host['enabled']:
+        util.SMlog("Xapi is not enabled, exiting")
+        mpc_exit(session, 0)
+
+
 if __name__ == '__main__':
     try:
         session = util.get_localAPI_session()
@@ -207,6 +215,7 @@ if __name__ == '__main__':
         sys.exit(-1)
 
     localhost = session.xenapi.host.get_by_uuid(get_localhost_uuid())
+    check_xapi_is_enabled(session, localhost)
     # Check whether multipathing is enabled (either for root dev or SRs)
     try:
         if get_root_dev_major() != get_dm_major():

--- a/drivers/sr_health_check.py
+++ b/drivers/sr_health_check.py
@@ -24,6 +24,11 @@ import SR
 import util
 import xs_errors
 
+def check_xapi_is_enabled(session, hostref):
+    host = session.xenapi.host.get_record(hostref)
+    return host['enabled']
+
+
 def main():
     """
     For all locally plugged SRs check that they are healthy
@@ -36,6 +41,9 @@ def main():
 
     try:
         localhost = util.get_localhost_ref(session)
+        if not check_xapi_is_enabled(session, localhost):
+            # Xapi not enabled, skip and let the next timer trigger this
+            return
 
         sm_types = [x['type'] for x in session.xenapi.SM.get_all_records_where(
             'field "required_api_version" = "1.0"').values()]

--- a/tests/test_mpathcount.py
+++ b/tests/test_mpathcount.py
@@ -209,3 +209,29 @@ class TestMpathCount(unittest.TestCase):
         # Assert
         mock_exit.assert_called_once_with(0)
         session.xenapi.session.logout.assert_called_once()
+
+    @mock.patch('mpathcount.sys.exit', autospec=True)
+    def test_check_xapi_enabled_yes(self, mock_exit):
+        # Arrange
+        session = mock.MagicMock()
+        session.xenapi.host.get_record.return_value = {'enabled': True}
+        hostref = mock.MagicMock()
+
+        # Act
+        mpathcount.check_xapi_is_enabled(session, hostref)
+
+        # Assert
+        mock_exit.assert_not_called()
+
+    @mock.patch('mpathcount.sys.exit', autospec=True)
+    def test_check_xapi_enabled_no(self, mock_exit):
+        # Arrange
+        session = mock.MagicMock()
+        session.xenapi.host.get_record.return_value = {'enabled': False}
+        hostref = mock.MagicMock()
+
+        # Act
+        mpathcount.check_xapi_is_enabled(session, hostref)
+
+        # Assert
+        mock_exit.assert_called_once_with(0)

--- a/tests/test_sr_health_check.py
+++ b/tests/test_sr_health_check.py
@@ -91,3 +91,15 @@ class TestSrHealthCheck(unittest.TestCase):
 
         # Assert
         mock_sr.check_sr.assert_called_with(SR_UUID)
+
+    def test_check_xapi_enabled_no(self):
+        # Arrange
+        self.mock_session.xenapi.host.get_record.return_value = {'enabled': False}
+        mock_sr = mock.create_autospec(SR)
+        self.mock_sr.from_uuid.return_value = mock_sr
+
+        # Act
+        sr_health_check.main()
+
+        # Assert
+        mock_sr.check_sr.assert_not_called()


### PR DESCRIPTION
We had a flurry of these issues as fallout from an, independent, xapi startup issue. So handle the condition gracefully with a log entry and don't backtrace the exception