### PR TITLE
CP-51658: install script to allow stopping all in-progress GC operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,8 @@ install: precheck
 	install -m 755 scripts/usb_change $(SM_STAGING)$(LIBEXEC)
 	install -m 755 scripts/kickpipe $(SM_STAGING)$(LIBEXEC)
 	install -m 755 scripts/set-iscsi-initiator $(SM_STAGING)$(LIBEXEC)
+	mkdir -p $(SM_STAGING)/etc/xapi.d/xapi-pre-shutdown/
+	install -m 755 scripts/stop_all_gc $(SM_STAGING)/etc/xapi.d/xapi-pre-shutdown/
 	$(MAKE) -C dcopy install DESTDIR=$(SM_STAGING)
 	ln -sf $(SM_DEST)blktap2.py $(SM_STAGING)$(BIN_DEST)/blktap2
 	ln -sf $(SM_DEST)lcache.py $(SM_STAGING)$(BIN_DEST)tapdisk-cache-stats

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -116,6 +116,7 @@ tests/run_python_unittests.sh
 /etc/xapi.d/plugins/testing-hooks
 /etc/xapi.d/plugins/intellicache-clean
 /etc/xapi.d/plugins/trim
+/etc/xapi.d/xapi-pre-shutdown/*
 /etc/xensource/master.d/02-vhdcleanup
 /opt/xensource/bin/blktap2
 /opt/xensource/bin/tapdisk-cache-stats

--- a/scripts/stop_all_gc
+++ b/scripts/stop_all_gc
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+/usr/bin/systemctl list-units SMGC@* --all --no-legend | /usr/bin/cut -d ' ' -f1 | sed 's/\\/\\\\/g' | while read service;
+do
+    echo "Stopping $service"
+    /usr/bin/systemctl stop "$service"
+done


### PR DESCRIPTION
The intent being that before the toolstack restart operation actually stops xapi that this script will be called and stop all in-flight GC processes so that they don't try and make use of xapi services whilst it is restarting and potentially leave VMs in the paused state due to being unable to unpause them on a supporter node due to a lack of a local xapi process to forward the on-host plugin call.