### PR TITLE
CA-400106: disable leaf coalesce with VDI snapshot secondary

### DIFF
--- a/drivers/FileSR.py
+++ b/drivers/FileSR.py
@@ -707,7 +707,7 @@ class FileVDI(VDI.VDI):
         vhdutil.killData(self.path)
 
     def _do_snapshot(self, sr_uuid, vdi_uuid, snap_type,
-                     secondary=None, cbtlog=None):
+                     _=False, secondary=None, cbtlog=None):
         # If cbt enabled, save file consistency state
         if cbtlog is not None:
             if blktap2.VDI.tap_status(self.session, vdi_uuid):
@@ -727,6 +727,7 @@ class FileVDI(VDI.VDI):
         try:
             return self._snapshot(snap_type, cbtlog, consistency_state)
         finally:
+            self.disable_leaf_on_secondary(vdi_uuid, secondary=secondary)
             blktap2.VDI.tap_unpause(self.session, sr_uuid, vdi_uuid, secondary)
 
     def _rename(self, src, dst):

--- a/drivers/LVHDSR.py
+++ b/drivers/LVHDSR.py
@@ -1656,6 +1656,7 @@ class LVHDVDI(VDI.VDI):
                 util.SMlog('WARNING: failed to clean up failed snapshot: '
                         '%s (error ignored)' % e2)
             raise
+        self.disable_leaf_on_secondary(vdi_uuid, secondary=secondary)
         blktap2.VDI.tap_unpause(self.session, sr_uuid, vdi_uuid, secondary)
         unpause_time = time.time()
         if (unpause_time - pause_time) > LONG_SNAPTIME:


### PR DESCRIPTION
When the secondary/mirror option is provided to the vdi_snasphot operation we do not want any leaf coalesce garbage collection taking place. Unfortunately xapi will delete the snapshot once it's finished copying the new parent to the destination SR in SXM and whilst the mirroring operation is still live. This will kick the GC process and if the GC gets to the point of performing the leaf coalesce before the migrate completes will result in a failure of the mirror operation. So block the leaf-coalesce operation in this case. The block will be removed if another snapshot were to be taken but in the case of SXM the next expected operation is a vdi_delete of the leaf which will clear the entire chain.