### PR TITLE
CA-400743: perform post snapshot rename in ioretry

### DIFF
--- a/drivers/FileSR.py
+++ b/drivers/FileSR.py
@@ -803,7 +803,10 @@ class FileVDI(VDI.VDI):
                 "FileSR_fail_snap1",
                 self.__fist_enospace)
             util.ioretry(lambda: self._snap(tmpsrc, newsrcname))
-            self._rename(tmpsrc, src)
+            # SMB3 can return EACCES if we attempt to rename over the
+            # hardlink leaf too quickly after creating it.
+            util.ioretry(lambda: self._rename(tmpsrc, src),
+                         errlist=[errno.EIO, errno.EACCES])
             if snap_type == VDI.SNAPSHOT_DOUBLE:
                 # Fault injection site to fail the snapshot with ENOSPACE
                 util.fistpoint.activate_custom_fn(


### PR DESCRIPTION
It appears that SMB3 filers or Windows hosts can return EACCES in response to a rename of a file over one of the links to a file if the rename is done too soon after the hardlink is made. Allow the rename to be retried in the event of EIO or ACCES.