### PR TITLE
CA-401068: if iSCSI device path is not found scan the bus

### DIFF
--- a/drivers/BaseISCSI.py
+++ b/drivers/BaseISCSI.py
@@ -422,6 +422,10 @@ class BaseISCSISR(SR.SR):
                 self.mpathmodule.refresh(self.dconf['SCSIid'], 0)
             dev_path = os.path.join("/dev/disk/by-scsid", self.dconf['SCSIid'])
             if not os.path.exists(dev_path):
+                # LUN may have been added to the SAN since the session was created
+                iscsilib.refresh_luns(self.targetIQN, self.target)
+
+            if not os.path.exists(dev_path):
                 raise xs_errors.XenError('ConfigSCSIid')
 
             devs = os.listdir(dev_path)


### PR DESCRIPTION
It's possible that a new LUN has been exported since we created the iSCSI session and we might not see it. Try to scan the iSCSI bus and see if the expected device appears.