### PR TITLE
CP-52844: allow for open session to be passed to sr_get_capability

### DIFF
--- a/drivers/SRCommand.py
+++ b/drivers/SRCommand.py
@@ -240,7 +240,8 @@ class SRCommand:
 
         elif self.cmd == 'vdi_delete':
             if 'VDI_CONFIG_CBT' in util.sr_get_capability(
-                                        self.params['sr_uuid']):
+                    self.params['sr_uuid'],
+                    session=sr.session):
                 return target.delete(self.params['sr_uuid'],
                                      self.vdi_uuid, data_only=False)
             else:

--- a/drivers/VDI.py
+++ b/drivers/VDI.py
@@ -812,7 +812,8 @@ class VDI(object):
             uuid = self.uuid
         if self.vdi_type == vhdutil.VDI_TYPE_RAW:
             return False
-        elif 'VDI_CONFIG_CBT' not in util.sr_get_capability(self.sr.uuid):
+        elif 'VDI_CONFIG_CBT' not in util.sr_get_capability(
+                self.sr.uuid, session=self.sr.session):
             return False
         logpath = self._get_cbt_logpath(uuid)
         return self._cbt_log_exists(logpath)

--- a/drivers/trim_util.py
+++ b/drivers/trim_util.py
@@ -98,7 +98,7 @@ def do_trim(session, args):
     sr_uuid = args["sr_uuid"]
     os.environ['LVM_SYSTEM_DIR'] = MASTER_LVM_CONF
 
-    if TRIM_CAP not in util.sr_get_capability(sr_uuid):
+    if TRIM_CAP not in util.sr_get_capability(sr_uuid, session=session):
         util.SMlog("Trim command ignored on unsupported SR %s" % sr_uuid)
         err_msg = {ERROR_CODE_KEY: 'UnsupportedSRForTrim',
                    ERROR_MSG_KEY: 'Trim on [%s] not supported' % sr_uuid}

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -375,9 +375,13 @@ def ioretry_stat(path, maxretry=IORETRY_MAX):
     raise CommandException(errno.EIO, "os.statvfs")
 
 
-def sr_get_capability(sr_uuid):
+def sr_get_capability(sr_uuid, session=None):
     result = []
-    session = get_localAPI_session()
+    local_session = None
+    if session is None:
+        local_session = get_localAPI_session()
+        session = local_session
+
     try:
         sr_ref = session.xenapi.SR.get_by_uuid(sr_uuid)
         sm_type = session.xenapi.SR.get_record(sr_ref)['type']
@@ -390,7 +394,8 @@ def sr_get_capability(sr_uuid):
 
         return result
     finally:
-        session.xenapi.session.logout()
+        if local_session:
+            local_session.xenapi.session.logout()
 
 def sr_get_driver_info(driver_info):
     results = {}


### PR DESCRIPTION
sr_get_capability can create, and subsequently log out a local Xapi session, however the users of the method will most likely already have an open session so allow that to be passed to avoid session churn in xapi.