### PR TITLE
CP-52852: add handler for xmlrpc ProtocolError

### DIFF
--- a/drivers/SRCommand.py
+++ b/drivers/SRCommand.py
@@ -17,11 +17,13 @@
 #
 # SRCommand: parse SR command-line objects
 #
+import traceback
 
 import XenAPI # pylint: disable=import-error
 import sys
 import xs_errors
 import xmlrpc.client
+from xmlrpc.client import ProtocolError
 import SR
 import util
 import blktap2
@@ -390,6 +392,14 @@ def run(driver, driver_info):
         else:
             print(ret)
 
+    except ProtocolError:
+        # xs_errors.XenError.__new__ returns a different class
+        # pylint: disable-msg=E1101
+        exception_trace = traceback.format_exc()
+        util.SMlog(f'XenAPI Protocol error {exception_trace}')
+        print(xs_errors.XenError(
+            'APIProtocolError',
+            opterr=exception_trace).toxml())
     except (Exception, xs_errors.SRException) as e:
         try:
             util.logException(driver_info['name'])

--- a/drivers/XE_SR_ERRORCODES.xml
+++ b/drivers/XE_SR_ERRORCODES.xml
@@ -534,6 +534,11 @@
                 <description>A Failure occurred accessing an API object</description>
                 <value>153</value>
         </code>
+        <code>
+                <name>APIProtocolError</name>
+                <description>A protocol error was received when accessing the API</description>
+                <value>154</value>
+        </code>
 
         <!-- Netapp Specific Error codes -->
         <code>


### PR DESCRIPTION
It is possible that a XenAPI call to xapi will result in an xmlrpc ProtocolError being returned, typically a 500 Internal Error. As it is not practical to wrap all the calls to xapi via the xenapi session in a specific exception handler add one into the outer run method to ensure that it is converted to an error code and not an unknown error.