### PR TITLE
CA-403952: Fix TapCtl._errmsg() bytes/str type issue

### DIFF
--- a/drivers/blktap2.py
+++ b/drivers/blktap2.py
@@ -213,7 +213,7 @@ class TapCtl(object):
         return cls(cmd, p)
 
     def _errmsg(self):
-        output = map(str.rstrip, self._p.stderr)
+        output = (line.rstrip() if isinstance(line, str) else line.decode('utf-8').rstrip() for line in self._p.stderr)
         return "; ".join(output)
 
     def _wait(self, quiet=False):


### PR DESCRIPTION
TapCtl runs in binary mode when handling encryption key, so the stderr is of 'bytes' type,
while 'str.rstrip' in _errmsg expects a 'str' object. This results in a bytes/str type mismatch issue.

Locally tested:
Wrote a simple test where `line1` is a `bytes` and `line2` is a `str`
```
errinfo = [b"line1 ", "line2 ", " lin3"]
# output = map(str.rstrip, errinfo)
output = (line.rstrip() if isinstance(line, str) else line.decode('utf-8').rstrip() for line in errinfo)
print("; ".join(output))
```
The output is correct:
```
(3.11.0) stephenche@39:~/temp$ python3 rstrip.py 
line1; line2;  lin3
```