### PR TITLE
Add udev rules for PureStorage - best practices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ SM_LIBS += constants
 SM_LIBS += cbtutil
 SM_LIBS += sr_health_check
 
-UDEV_RULES = 65-multipath 55-xs-mpath-scsidev 57-usb 58-xapi
+UDEV_RULES = 65-multipath 55-xs-mpath-scsidev 57-usb 58-xapi 99-purestorage
 MPATH_DAEMON = sm-multipath
 MPATH_CONF = multipath.conf
 MPATH_CUSTOM_CONF = custom.conf

--- a/mk/sm.spec.in
+++ b/mk/sm.spec.in
@@ -221,6 +221,8 @@ tests/run_python_unittests.sh
 %config /etc/udev/rules.d/69-dm-lvm-metad.rules
 %config /etc/logrotate.d/SMlog
 %config /etc/udev/rules.d/57-usb.rules
+%config /etc/udev/rules.d/99-purestorage.rules
+
 %doc CONTRIB LICENSE MAINTAINERS README.md
 
 %package fairlock

--- a/udev/99-purestorage.rules
+++ b/udev/99-purestorage.rules
@@ -1,0 +1,15 @@
+# Recommended settings for Pure Storage FlashArray.
+# Use none scheduler for high-performance solid-state storage for SCSI devices
+ACTION=="add|change", KERNEL=="sd*[!0-9]", SUBSYSTEM=="block", ENV{ID_VENDOR}=="PURE", ATTR{queue/scheduler}="none"
+ACTION=="add|change", KERNEL=="dm-[0-9]*", SUBSYSTEM=="block", ENV{DM_NAME}=="3624a937*", ATTR{queue/scheduler}="none"
+
+# Reduce CPU overhead due to entropy collection
+ACTION=="add|change", KERNEL=="sd*[!0-9]", SUBSYSTEM=="block", ENV{ID_VENDOR}=="PURE", ATTR{queue/add_random}="0"
+ACTION=="add|change", KERNEL=="dm-[0-9]*", SUBSYSTEM=="block", ENV{DM_NAME}=="3624a937*", ATTR{queue/add_random}="0"
+
+# Spread CPU load by redirecting completions to originating CPU
+ACTION=="add|change", KERNEL=="sd*[!0-9]", SUBSYSTEM=="block", ENV{ID_VENDOR}=="PURE", ATTR{queue/rq_affinity}="2"
+ACTION=="add|change", KERNEL=="dm-[0-9]*", SUBSYSTEM=="block", ENV{DM_NAME}=="3624a937*", ATTR{queue/rq_affinity}="2"
+
+# Set the HBA timeout to 60 seconds
+ACTION=="add|change", KERNEL=="sd*[!0-9]", SUBSYSTEM=="block", ENV{ID_VENDOR}=="PURE", ATTR{device/timeout}="60"

--- a/udev/99-purestorage.rules
+++ b/udev/99-purestorage.rules
@@ -12,4 +12,4 @@ ACTION=="add|change", KERNEL=="sd*[!0-9]", SUBSYSTEM=="block", ENV{ID_VENDOR}=="
 ACTION=="add|change", KERNEL=="dm-[0-9]*", SUBSYSTEM=="block", ENV{DM_NAME}=="3624a937*", ATTR{queue/rq_affinity}="2"
 
 # Set the HBA timeout to 60 seconds
-ACTION=="add|change", KERNEL=="sd*[!0-9]", SUBSYSTEM=="block", ENV{ID_VENDOR}=="PURE", ATTR{device/timeout}="60"
+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{model}=="FlashArray      ", RUN+="/bin/sh -c 'echo 60 > /sys/$DEVPATH/device/timeout'"

--- a/udev/99-purestorage.rules
+++ b/udev/99-purestorage.rules
@@ -9,7 +9,5 @@ ACTION=="add|change", KERNEL=="dm-[0-9]*", SUBSYSTEM=="block", ENV{DM_NAME}=="36
 
 # Spread CPU load by redirecting completions to originating CPU
 ACTION=="add|change", KERNEL=="sd*[!0-9]", SUBSYSTEM=="block", ENV{ID_VENDOR}=="PURE", ATTR{queue/rq_affinity}="2"
-ACTION=="add|change", KERNEL=="dm-[0-9]*", SUBSYSTEM=="block", ENV{DM_NAME}=="3624a937*", ATTR{queue/rq_affinity}="2"
 
-# Set the HBA timeout to 60 seconds
-ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{model}=="FlashArray      ", RUN+="/bin/sh -c 'echo 60 > /sys/$DEVPATH/device/timeout'"
+ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{model}=="FlashArray      ", ATTR{device/timeout}="60"


### PR DESCRIPTION
This commit integrates PureStorage-recommended udev rules to optimize queue settings for Citrix XenServer. These changes follow the guidelines outlined in the PureStorage Knowledge Base article [#kbid](https://support.purestorage.com/bundle/m_citrix/page/Solutions/Citrix/Citrix_XenServer/topics/task/t_applying_queue_settings_with_udev.html).

Key changes:
- Implemented udev rules to adjust IO scheduler and queue depth for PureStorage volumes.
- Ensured compliance with existing XenServer storage management (SM) conventions.
- Verified functionality through test scenarios to avoid regression with non-PureStorage configurations.

Motivation:
These changes aim to improve performance and reliability for deployments using PureStorage arrays, adhering to vendor-recommended best practices while maintaining compatibility with the broader XenServer ecosystem.

Testing:
- Manually verified udev rules on test systems with PureStorage arrays.
- Confirmed compatibility with non-PureStorage environments.
- Ran unit tests for related storage subsystems.

This change is backward-compatible, introduces no breaking changes and only affect PureStorage arrays.