### PR TITLE
CP-53783: use os.path.realpath instead of incorrect internal

### DIFF
--- a/drivers/cleanup.py
+++ b/drivers/cleanup.py
@@ -250,13 +250,6 @@ class Util:
         return count
     countBits = staticmethod(countBits)
 
-    def getThisScript():
-        thisScript = util.get_real_path(__file__)
-        if thisScript.endswith(".pyc"):
-            thisScript = thisScript[:-1]
-        return thisScript
-    getThisScript = staticmethod(getThisScript)
-
 
 ################################################################################
 #

--- a/drivers/mpath_dmp.py
+++ b/drivers/mpath_dmp.py
@@ -135,7 +135,7 @@ def _is_valid_multipath_device(sid):
         # Some paths might be down, check all associated devices
         for dev in devs:
             devpath = os.path.join(by_scsid_path, dev)
-            real_path = util.get_real_path(devpath)
+            real_path = os.path.realpath(devpath)
             with Fairlock("devicemapper"):
                 (ret, stdout, stderr) = util.doexec(['/usr/sbin/multipath', '-c', real_path])
                 if ret == 0:

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -500,17 +500,6 @@ def get_secret(session, uuid):
         raise xs_errors.XenError('InvalidSecret', opterr='Unable to look up secret [%s]' % uuid)
 
 
-def get_real_path(path):
-    "Follow symlinks to the actual file"
-    absPath = path
-    directory = ''
-    while os.path.islink(absPath):
-        directory = os.path.dirname(absPath)
-        absPath = os.readlink(absPath)
-        absPath = os.path.join(directory, absPath)
-    return absPath
-
-
 def wait_for_path(path, timeout):
     for i in range(0, timeout):
         if len(glob.glob(path)):


### PR DESCRIPTION
The implementation in get_real_path does not correctly canonicalize the resulting path which anyuser of realpath would expect to be the case. Replace with the python standard library version.

Also remove the unused getThisScript method from cleanup.py which also used this method.