### PR TITLE
CP-50026 Ensure mpathcount runs after multipath deactivate

### DIFF
--- a/drivers/mpath_dmp.py
+++ b/drivers/mpath_dmp.py
@@ -219,6 +219,7 @@ def deactivate():
     if iscsilib.is_iscsi_daemon_running() and not iscsilib._checkAnyTGT():
         iscsilib.restart_daemon()
 
+    util.kickpipe_mpathcount()
     util.SMlog("MPATH: multipath deactivated.")
 
 

--- a/drivers/util.py
+++ b/drivers/util.py
@@ -62,6 +62,7 @@ LOG_DEBUG = syslog.LOG_DEBUG
 ISCSI_REFDIR = '/var/run/sr-ref'
 
 CMD_DD = "/bin/dd"
+CMD_KICKPIPE = '/opt/xensource/libexec/kickpipe'
 
 FIST_PAUSE_PERIOD = 30  # seconds
 
@@ -967,6 +968,16 @@ def remove_mpathcount_field(session, host_ref, sr_ref, SCSIid):
     except:
         pass
 
+
+def kickpipe_mpathcount():
+    """
+    Issue a kick to the mpathcount service. This will ensure that mpathcount runs
+    shortly to update the multipath config records, if it was not already activated
+    by a UDEV event.
+    """
+    cmd = [CMD_KICKPIPE, "mpathcount"]
+    (rc, stdout, stderr) = doexec(cmd)
+    return (rc == 0)
 
 
 def _testHost(hostname, port, errstring):


### PR DESCRIPTION
Some orders of doing things do not trigger udev events with the right timing to get the multipath config records updated when multipath is shut down entirely.

Deliberately kick the mpathcount pipe after multipath is deactivated, which will ensure that the mpathcount service runs shortly after. If it had already been kicked and had not yet run, this extra kick will have no effect.