### PR TITLE
iSCSI udev rules for PureStorage - Correction of an old PR (#729)

### DIFF
--- a/udev/99-purestorage.rules
+++ b/udev/99-purestorage.rules
@@ -9,5 +9,6 @@ ACTION=="add|change", KERNEL=="dm-[0-9]*", SUBSYSTEM=="block", ENV{DM_NAME}=="36
 
 # Spread CPU load by redirecting completions to originating CPU
 ACTION=="add|change", KERNEL=="sd*[!0-9]", SUBSYSTEM=="block", ENV{ID_VENDOR}=="PURE", ATTR{queue/rq_affinity}="2"
+ACTION=="add|change", KERNEL=="dm-[0-9]*", SUBSYSTEM=="block", ENV{DM_NAME}=="3624a937*", ATTR{queue/rq_affinity}="2"
 
 ACTION=="add", SUBSYSTEMS=="scsi", ATTRS{model}=="FlashArray      ", ATTR{device/timeout}="60"


### PR DESCRIPTION
Restore udev configuration line deleted by error in PR [#729](https://github.com/xapi-project/sm/pull/729)

Related discussion: [https://github.com/xapi-project/sm/pull/729#discussion_r1982945403](https://github.com/xapi-project/sm/pull/729#discussion_r1982945403)