### PR TITLE
EXT: don't reserve any block for root

### DIFF
--- a/drivers/EXTSR.py
+++ b/drivers/EXTSR.py
@@ -205,7 +205,7 @@ class EXTSR(FileSR.FileSR):
                 opterr='Insufficient space in VG %s' % self.vgname)
 
         try:
-            util.pread2(["mkfs.ext4", "-F", self.remotepath])
+            util.pread2(["mkfs.ext4", "-m", "0", "-F", self.remotepath])
         except util.CommandException as inst:
             raise xs_errors.XenError('LVMFilesystem',
                                      opterr='mkfs failed error %d' % inst.code)


### PR DESCRIPTION
There is only root in dom0, and `df` erroneously substracts the default 5% of disk space as "reserved for root", which is just meaningless here.

It could be worth going further with doing the same for all FileSR types, but I thought I'd ask for feedback first.

If this becomes a thing, it could be useful then to find some way to get `tune2fs -m 0` run on existing SR to make them even.