### PR TITLE
CP-53692 SR attach calls mpathcount async

### DIFF
--- a/drivers/SR.py
+++ b/drivers/SR.py
@@ -496,8 +496,7 @@ class SR(object):
             self.session.xenapi.SR.set_sm_config(self.sr_ref, sm_config)
 
             if self.mpath == "true" and len(SCSIid):
-                cmd = ['/opt/xensource/sm/mpathcount.py', SCSIid]
-                util.pread2(cmd)
+                util.kickpipe_mpathcount()
         except:
             pass
 


### PR DESCRIPTION
Kickpipe as subprocess to run mpathcount script in the background to avoid the synchronously calling block the SR attach process.

The original implementation will pass a `SCSIid` to the mpathcount script, however I think this script will not handler a extra parameter at the moment. so it is an unnecessary parameter.

BST - 214740 

Limit configure test -  21474