### PR TITLE
Prevent fairlock from being stopped before xapi

### DIFF
--- a/misc/fairlock/fairlock@.service
+++ b/misc/fairlock/fairlock@.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Co-operative lock manager for resource %I
+Before=xapi.service
 DefaultDependencies=no
 
 [Service]


### PR DESCRIPTION
When shutting down or rebooting, Xapi will call things in SM which want to use the fairlock service, but newer systemd will refuse to start it because it already has it stopping as part of the current transaction.

Ensure systemd does not stop fairlock until after Xapi, to prevent this from being a problem.