### PR TITLE
CA-411927: guard check with presence of ScsiId key

### DIFF
--- a/libs/sm/mpathcount.py
+++ b/libs/sm/mpathcount.py
@@ -156,7 +156,7 @@ def get_SCSIidlist(devconfig, sm_config):
         SCSIidlist = sm_config['SCSIid'].split(',')
     elif 'SCSIid' in devconfig:
         SCSIidlist.append(devconfig['SCSIid'])
-    elif 'provider' in devconfig:
+    elif 'provider' in devconfig and 'ScsiId' in devconfig:
         SCSIidlist.append(devconfig['ScsiId'])
     else:
         for key in sm_config:


### PR DESCRIPTION
Otherwise we can get a key error. This check is looking for a legacy ScsiId key which only existed in some experimental SM implementations. Just be careful to ensure that both provider and ScsiId exist in case this is necessary.