### PR TITLE
CA-395221: use systemd target for gc enable

### DIFF
--- a/libs/sm/cleanup.py
+++ b/libs/sm/cleanup.py
@@ -3115,32 +3115,8 @@ def _gcLoop(sr, dryRun=False, immediate=False):
         lockGCActive.release()
 
 
-def _xapi_enabled(session, hostref):
-    host = session.xenapi.host.get_record(hostref)
-    return host['enabled']
-
-
-def _ensure_xapi_initialised(session):
-    """
-    Don't want to start GC until Xapi is fully initialised
-    """
-    local_session = None
-    if session is None:
-        local_session = util.get_localAPI_session()
-        session = local_session
-
-    try:
-        hostref = session.xenapi.host.get_by_uuid(util.get_this_host())
-        while not _xapi_enabled(session, hostref):
-            util.SMlog("Xapi not ready, GC waiting")
-            time.sleep(15)
-    finally:
-        if local_session is not None:
-            local_session.xenapi.session.logout()
-
 def _gc(session, srUuid, dryRun=False, immediate=False):
     init(srUuid)
-    _ensure_xapi_initialised(session)
     sr = SR.getInstance(srUuid, session)
     if not sr.gcEnabled(False):
         return

--- a/systemd/SMGC@.service
+++ b/systemd/SMGC@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Garbage Collector for SR %I
 DefaultDependencies=no
+Requires=xapi-init-complete.target
 
 [Service]
 Type=oneshot

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -184,8 +184,7 @@ class TestSR(unittest.TestCase):
 
     @mock.patch('sm.cleanup._create_init_file', autospec=True)
     @mock.patch('sm.cleanup.SR', autospec=True)
-    @mock.patch('sm.cleanup._ensure_xapi_initialised', autospec=True)
-    def test_loop_exits_on_term(self, mock_init, mock_sr, mock_check_xapi):
+    def test_loop_exits_on_term(self, mock_init, mock_sr):
         # Set the term signel
         cleanup.receiveSignal(signal.SIGTERM, None)
         mock_session = mock.MagicMock(name='MockSession')
@@ -1679,71 +1678,6 @@ class TestSR(unittest.TestCase):
         self.assertIn('Failed to tag vdi', str(sme.exception))
 
         self.assertGreater(self.mock_time_sleep.call_count, 5)
-
-    @mock.patch('sm.cleanup.util.get_this_host', autospec=True)
-    @mock.patch('sm.cleanup._gcLoop', autospec=True)
-    @mock.patch('sm.cleanup.SR.getInstance')
-    def test_check_for_xapi_running(
-            self, mock_sr, mock_loop, mock_this_host):
-        """
-        Check we start immediately if xapi is enabled
-        """
-        host_uuid = uuid4()
-        mock_this_host.return_value = host_uuid
-
-        mock_session = mock.MagicMock(name='MockSession')
-        mock_session.xenapi.host.get_record.return_value = {
-            'enabled': True
-        }
-        sr_uuid = uuid4()
-
-        cleanup._gc(mock_session, sr_uuid, False)
-
-    @mock.patch('sm.cleanup.util.get_this_host', autospec=True)
-    @mock.patch('sm.cleanup.util.get_localAPI_session', autospec=True)
-    @mock.patch('sm.cleanup._gcLoop', autospec=True)
-    @mock.patch('sm.cleanup.SR.getInstance')
-    def test_check_for_xapi_running_no_session(
-            self, mock_sr, mock_loop, mock_get_session, mock_this_host):
-        """
-        Check we start immediately if xapi is enabled
-        """
-        host_uuid = uuid4()
-        mock_this_host.return_value = host_uuid
-        mock_session = mock.MagicMock(name='MockSession')
-        mock_get_session.return_value = mock_session
-
-        mock_session.xenapi.host.get_record.return_value = {
-            'enabled': True
-        }
-        sr_uuid = uuid4()
-
-        cleanup._gc(None, sr_uuid, False)
-
-    @mock.patch('sm.cleanup.util.get_this_host', autospec=True)
-    @mock.patch('sm.cleanup.util.get_localAPI_session', autospec=True)
-    @mock.patch('sm.cleanup._gcLoop', autospec=True)
-    @mock.patch('sm.cleanup.SR.getInstance')
-    def test_waits_for_xapi_running(
-            self, mock_sr, mock_loop, mock_get_session, mock_this_host):
-        """
-        Check we start immediately if xapi is enabled
-        """
-        host_uuid = uuid4()
-        mock_this_host.return_value = host_uuid
-        mock_session = mock.MagicMock(name='MockSession')
-        mock_get_session.return_value = mock_session
-
-        mock_session.xenapi.host.get_record.side_effect = [
-            {'enabled': False},
-            {'enabled': False},
-            {'enabled': True}
-        ]
-        sr_uuid = uuid4()
-
-        cleanup._gc(None, sr_uuid, False)
-
-        self.assertEqual(3, mock_session.xenapi.host.get_record.call_count)
 
     def init_gc_loop_sr(self):
         sr_uuid = str(uuid4())


### PR DESCRIPTION
The xapi enabled state does not reflect whether the local xapi process is able to respond to requests and only whether the host is enabled to run new VMs. It is therefore not a useful check to ensure the GC will be able to make requests of xapi. Switch instead to making the service require the xapi-init-complete.target which will at least ensure the local xapi has completed its initialisation which was the original intent of this check.