### PR TITLE
CA-412080 Add lcache to SM_LIBS to resolve tapdisk-cache-stats import error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ SM_LIBS += devscan
 SM_LIBS += fjournaler
 SM_LIBS += ipc
 SM_LIBS += journaler
+SM_LIBS += lcache
 SM_LIBS += lock_queue
 SM_LIBS += LUNperVDI
 SM_LIBS += lvhdutil


### PR DESCRIPTION
The tapdisk-cache-stats script imports sm.lcache but the module wasn't being installed due to missing entry in Makefile's SM_LIBS list.

(rerun 4352152 passed)