### PR TITLE
CA-413209: remove dangling reference to rawhba

### DIFF
--- a/libs/sm/mpathcount.py
+++ b/libs/sm/mpathcount.py
@@ -23,7 +23,7 @@ from sm.core import util
 from sm.core import xs_errors
 from sm.core import mpath_cli
 
-supported = ['iscsi', 'lvmoiscsi', 'rawhba', 'lvmohba', 'ocfsohba', 'ocfsoiscsi', 'netapp', 'gfs2']
+supported = ['iscsi', 'lvmoiscsi', 'lvmohba', 'gfs2']
 
 LOCK_TYPE_HOST = "host"
 LOCK_NS1 = "mpathcount1"


### PR DESCRIPTION
And while we're at it remove the other dangling references to ocfs and netapp.