### PR TITLE
lvhdutil: fix sr_uuid handling

### DIFF
--- a/libs/sm/lvhdutil.py
+++ b/libs/sm/lvhdutil.py
@@ -81,7 +81,8 @@ def extractUuid(path):
     if uuid.startswith(VG_PREFIX):
         # we are dealing with realpath
         uuid = uuid.replace("--", "-")
-        uuid.replace(VG_PREFIX, "")
+        uuid = uuid.replace(VG_PREFIX, "")
+        return uuid
     for t in VDI_TYPES:
         if uuid.find(LV_PREFIX[t]) != -1:
             uuid = uuid.split(LV_PREFIX[t])[-1]


### PR DESCRIPTION
The `uuid.replace(VG_PREFIX, "")` does nothing.
This codepath is only used if we give path = "VG_XenStorage-<SR UUID>", the goal maybe being to get the SR UUID from VG Name, in this case we return the UUID.
Otherwise, the function will only return an empty string.