### PR TITLE
Fix regression introduced in 28efafcf46594ff2ed5ec0ffa3099f10d44b07e4

### DIFF
--- a/libs/sm/lvhdutil.py
+++ b/libs/sm/lvhdutil.py
@@ -81,8 +81,7 @@ def extractUuid(path):
     if uuid.startswith(VG_PREFIX):
         # we are dealing with realpath
         uuid = uuid.replace("--", "-")
-        uuid = uuid.replace(VG_PREFIX, "")
-        return uuid
+
     for t in VDI_TYPES:
         if uuid.find(LV_PREFIX[t]) != -1:
             uuid = uuid.split(LV_PREFIX[t])[-1]


### PR DESCRIPTION
28efafcf46594ff2ed5ec0ffa3099f10d44b07e4 incorrectly added a return to extractUUID which resulted in returning garbage to the caller rather than the expected LV UUID.