### PR TITLE
fix: stop SMGC service on SR detach to prevent orphaned systemd units

### DIFF
--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -398,7 +398,7 @@ class TestSR(unittest.TestCase):
         cleanup.lockGCActive = TestRelease()
         cleanup.lockGCActive.release = mock.Mock(return_value=None)
 
-        ret = cleanup.abort(mock_sr, False)
+        ret = cleanup.abort(str(mock_sr.uuid), False)
 
         # Pass on the return from _abort.
         self.assertEqual(True, ret)


### PR DESCRIPTION
This is not done on every and each implementation of SR but only on ones that calls `cleanup.start_gc_service` (like `FileSR`) and on the classes that inherits from them and don't call super on `detach`.

This is to prevent useless errors logs like `Failed to stop xxx.service: Unit xxx.service not loaded.`