### PR TITLE
CA-405851: stop_all_gc failed to stop SMGC services

### DIFF
--- a/scripts/stop_all_gc
+++ b/scripts/stop_all_gc
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-/usr/bin/systemctl list-units SMGC@* --all --no-legend | /usr/bin/cut -d ' ' -f1 | sed 's/\\/\\\\/g' | while read service;
+/usr/bin/systemctl list-units SMGC@* --all --no-legend | /usr/bin/awk '{print $1}' | sed 's/\\/\\\\/g' | while read service;
 do
     echo "Stopping $service"
     /usr/bin/systemctl stop "$service"


### PR DESCRIPTION
systemd has changed its output for command as folllows /usr/bin/systemctl list-units SMGC@*
============>
SMGC@1.service
SMGC@2.service
============
  SMGC@1.service
  SMGC@2.service
<============

Note: the extra space before the valid service name This means `cut -d' ' -f1` can no longer parse the service name. `awk` is used rather that `cut` to fix the issue