### PR TITLE
CA-413899: Rescan LVs whilst activating

### DIFF
--- a/libs/sm/lvmcache.py
+++ b/libs/sm/lvmcache.py
@@ -144,7 +144,7 @@ class LVMCache:
             count = RefCounter.get(ref, binary, ns)
             if count == 1:
                 try:
-                    self.activateNoRefcount(lvName)
+                    self.activateNoRefcount(lvName, True)
                 except util.CommandException:
                     RefCounter.put(ref, binary, ns)
                     raise


### PR DESCRIPTION
There is a small window where, if a VM is leaf coalesced whilst it is shutdown, that a subsequent atempt to activate the VDI will fail with `SR_BACKEND_FAILURE_46 (The VDI is not available)`. This appears to be due to the GC process not issuing a `_updateSlavesOnRename` request because the VDI is not active. To avoid this ensure that the `--refresh` is performed when attempting to attach/activate.