### PR TITLE
LVHDSR: convert VDI.ref retured by get_snapshot_of to vdi_uuid

### DIFF
--- a/libs/sm/drivers/LVHDSR.py
+++ b/libs/sm/drivers/LVHDSR.py
@@ -238,6 +238,7 @@ class LVHDSR(SR.SR):
             vdi_info = {}
             for vdi in self.session.xenapi.SR.get_VDIs(self.sr_ref):
                 vdi_uuid = self.session.xenapi.VDI.get_uuid(vdi)
+                is_a_snapshot = int(self.session.xenapi.VDI.get_is_a_snapshot(vdi))
 
                 vdi_type = self.session.xenapi.VDI.get_sm_config(vdi).get('vdi_type')
                 if not vdi_type:
@@ -250,9 +251,9 @@ class LVHDSR(SR.SR):
                     NAME_LABEL_TAG: util.to_plain_string(self.session.xenapi.VDI.get_name_label(vdi)),
                     NAME_DESCRIPTION_TAG: util.to_plain_string(self.session.xenapi.VDI.get_name_description(vdi)),
                     IS_A_SNAPSHOT_TAG: \
-                        int(self.session.xenapi.VDI.get_is_a_snapshot(vdi)),
+                        is_a_snapshot,
                     SNAPSHOT_OF_TAG: \
-                        self.session.xenapi.VDI.get_snapshot_of(vdi),
+                        self.session.xenapi.VDI.get_uuid(self.session.xenapi.VDI.get_snapshot_of(vdi)) if bool(is_a_snapshot) else '',
                    SNAPSHOT_TIME_TAG: \
                         self.session.xenapi.VDI.get_snapshot_time(vdi),
                     TYPE_TAG: \

--- a/libs/sm/srmetadata.py
+++ b/libs/sm/srmetadata.py
@@ -699,7 +699,6 @@ class LVMMetadataHandler(MetadataHandler):
             if created:
                 # Now delete the dummy VDI created above
                 self.deleteVdi(uuid)
-                return
 
     # This function generates VDI info based on the passed in information
     # it also takes in a parameter to determine whether both the sector

--- a/libs/sm/srmetadata.py
+++ b/libs/sm/srmetadata.py
@@ -634,7 +634,6 @@ class MetadataHandler:
         util.SMlog("Entering getMetadataToWrite")
         try:
             value = b""
-            vdi_map = {}
 
             # if lower is less than SR info
             if lower < SECTOR_SIZE * SR_INFO_SIZE_IN_SECTORS:


### PR DESCRIPTION
'scan' function uses SNAPSHOT_OF_TAG as a vdi_uuid. Same, function '_finishSnapshot', part of 'clone', initialize SNAPSHOT_OF_TAG field with a vdi_uuid.
Without this patch the MGT is filled with 'OpaqueRef:' VDI after MGT is recreated.

To reproduce:
1. Create a VDI with a snapshot on LVM SR `<SR UUID>`.
2. `lvremove /dev/VG_XenStorage-<SR UUID>/MGT`
3. `xe sr-scan uuid=<SR UUID>`