### PR TITLE
scripts: Use python3 explicitly

### DIFF
--- a/scripts/02-vhdcleanup
+++ b/scripts/02-vhdcleanup
@@ -31,7 +31,7 @@ start() {
         srUuids=`xe sr-list type=$type params=uuid --minimal | sed "s/,/ /g"`
         for uuid in $srUuids; do
             echo -n "Fixing $type"
-            python $LVHD_UTIL_SCRIPT fixrefcounts $uuid
+            python3 $LVHD_UTIL_SCRIPT fixrefcounts $uuid
         done
     done
 	echo -n $"OK"


### PR DESCRIPTION
In some cases, the unversioned python command may not exist.