### PR TITLE
CA-421013: ensure cbt log removed on supporter after disable

### DIFF
--- a/libs/sm/VDI.py
+++ b/libs/sm/VDI.py
@@ -572,6 +572,10 @@ class VDI(object):
             return False
         return True
 
+    def update_slaves_on_cbt_disable(self, cbtlog):
+        # Override in implementation as required.
+        pass
+
     def configure_blocktracking(self, sr_uuid, vdi_uuid, enable):
         """Function for configuring blocktracking"""
         from sm import blktap2
@@ -626,6 +630,8 @@ class VDI(object):
                     if self._cbt_log_exists(parent_path):
                         self._cbt_op(parent, cbtutil.set_cbt_child,
                                      parent_path, uuid.UUID(int=0))
+                    if disk_state:
+                        self.update_slaves_on_cbt_disable(logpath)
                 except Exception as error:
                     raise xs_errors.XenError('CBTDeactivateFailed', str(error))
                 finally:


### PR DESCRIPTION
When CBT is disabled the CBT log is deleted, on the coordinator, when using shared LVM SRs it is necessary to inform the supporter of this change so that it can remove all information relating to the CBT log volume from the kernel device mapper table. If this is not done a subsequent CBT enable for this VDI will fail if the device mapper table still contains information about the previous, and now deleted, volume.