### PR TITLE
CA-411988 Fix TypeError in LVHDoHBASR.load() with direct parent call 

### DIFF
--- a/libs/sm/drivers/LVHDoHBASR.py
+++ b/libs/sm/drivers/LVHDoHBASR.py
@@ -102,7 +102,7 @@ class LVHDoHBASR(LVHDSR.LVHDSR):
                 raise xs_errors.XenError('ConfigSCSIid')
 
         self.SCSIid = self.dconf['SCSIid']
-        super(LVHDoHBASR, self).load(sr_uuid)
+        LVHDSR.LVHDSR.load(self, sr_uuid)
 
     def create(self, sr_uuid, size):
         self.hbasr.attach(sr_uuid)


### PR DESCRIPTION
In some cases, `sr_health_check` fails with:

```
TypeError: super(type, obj): obj must be an instance or subtype of type
```
This occurs when `SR.from_uuid()` dynamically loads the module, potentially creating separate `LVHDoHBASR` class objects in memory. Python's super() validates class identity and fails when the class reference differs from the instance's class.

Replace `super(LVHDoHBASR, self).load(sr_uuid)` with `LVHDSR.LVHDSR.load(self, sr_uuid)`

This direct parent call bypasses class identity validation and aligns with all other methods(create, detach etc.) in this class.