### PR TITLE
fix(cleanup): properly handle FileSR exception for slave check

### DIFF
--- a/libs/sm/cleanup.py
+++ b/libs/sm/cleanup.py
@@ -2598,7 +2598,7 @@ class FileSR(SR):
                 raise AbortException("Aborting due to signal")
             try:
                 self._checkSlave(hostRef, vdi)
-            except util.CommandException:
+            except XenAPI.Failure:
                 if hostRef in onlineHosts:
                     raise
 


### PR DESCRIPTION
A plugin is used by the `_checkSlave` helper.
Therefore, `call_plugin` is executed instead of a command helper, which means that `CommandException` cannot be raised.